### PR TITLE
chore(web): migrate frontend to Vite+ (vp) and align devcontainer/Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -100,7 +100,7 @@ EOF
 RUN cat > /root/.zshrc <<'EOF'
 # zsh configuration for the dev container.
 
-export PATH="/root/go/bin:/usr/local/cargo/bin:/usr/local/go/bin:$PATH"
+export PATH="/root/.vite-plus/bin:/root/go/bin:/usr/local/cargo/bin:/usr/local/go/bin:$PATH"
 
 # Enable Starship prompt.
 eval "$(starship init zsh)"
@@ -133,12 +133,12 @@ alias gl='git log --oneline --graph --decorate'
 alias gco='git checkout'
 alias gb='git branch'
 
-alias pn='pnpm'
-alias pni='pnpm install'
-alias pnd='pnpm dev'
-alias pnb='pnpm build'
-alias pnt='pnpm test'
-alias pnl='pnpm lint'
+alias vpw='cd /workspace/web && vp'
+alias vpi='cd /workspace/web && vp install'
+alias vpd='cd /workspace/web && vp dev --host --port 6657'
+alias vpb='cd /workspace/web && vp build'
+alias vpt='cd /workspace/web && vp test'
+alias vpc='cd /workspace/web && vp check'
 
 alias dc='docker compose'
 alias dps='docker ps'
@@ -147,7 +147,7 @@ EOF
 RUN chsh -s /usr/bin/zsh root
 
 # ---------------------------------------------------------------
-# Node.js 23.x + pnpm (matches web/.nvmrc)
+# Node.js 23.x + Vite+ CLI (matches web/.nvmrc)
 # ---------------------------------------------------------------
 ARG NODE_VERSION=23.11.1
 
@@ -163,9 +163,11 @@ RUN set -eux; \
     rm "node-v${NODE_VERSION}-linux-${node_arch}.tar.xz"; \
     corepack enable; \
     corepack prepare pnpm@latest --activate; \
+    curl -fsSL https://vite.plus | bash; \
     node --version; \
     npm --version; \
-    pnpm --version
+    pnpm --version; \
+    /root/.vite-plus/bin/vp --version
 
 # ---------------------------------------------------------------
 # Rust toolchain (nightly + wasm target for WASM crates)
@@ -174,7 +176,7 @@ RUN set -eux; \
 # ---------------------------------------------------------------
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
-    PATH=/usr/local/cargo/bin:$PATH
+    PATH=/root/.vite-plus/bin:/usr/local/cargo/bin:$PATH
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
       --default-toolchain nightly-2025-11-15 \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,7 @@
             "onAutoForward": "notify"
         },
         "6657": {
-            "label": "Vite Dev Server (Web)",
+            "label": "Vite+ Dev Server (Web)",
             "onAutoForward": "openBrowserOnce"
         }
     },

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ WEB_DIR := web
 SERVER_DIR := server
 
 GO := go
-PNPM := pnpm
+VP := vp
 DOCKER := docker
 
 API_URL ?= http://localhost:6680
@@ -63,7 +63,7 @@ setup:
 	@echo "==> Installing Go dependencies"
 	cd $(SERVER_DIR) && $(GO) mod download
 	@echo "==> Installing web dependencies"
-	cd $(WEB_DIR) && $(PNPM) install
+	cd $(WEB_DIR) && $(VP) install
 	@echo "==> Ensuring wasm-pack is installed"
 	@command -v wasm-pack >/dev/null 2>&1 || { curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh; }
 	@echo "==> Ensuring river CLI is installed"
@@ -201,7 +201,7 @@ server-build:
 
 web-dev: env-web-dev
 	@echo "==> Starting web development server..."
-	cd $(WEB_DIR) && $(PNPM) run dev --host --port 6657
+	cd $(WEB_DIR) && $(VP) dev --host --port 6657
 
 dev: db-wait
 	@echo "==> Starting development environment..."

--- a/docs/development/vite-plus.md
+++ b/docs/development/vite-plus.md
@@ -1,0 +1,79 @@
+# Vite+ local setup and cleanup
+
+Lumilio Photos uses the Vite+ alpha toolchain for the frontend in `web/`. Vite+ provides the `vp` command, delegates package installs through the package manager declared by the project, and replaces the day-to-day Vite/Vitest/Oxlint commands.
+
+> Vite+ is still alpha software. If a `vp` command fails after an upstream alpha release, run `vp upgrade`, refresh the project dependencies with `vp install`, and check the Vite+ troubleshooting guide before changing application code.
+
+## One-time install on an existing nvm/pnpm machine
+
+From a shell that can reach the Vite+ installer and npm registry:
+
+```bash
+# 1. Keep your existing nvm installation, but use the project Node first.
+cd /path/to/Lumilio-Photos/web
+nvm install
+nvm use
+
+# 2. Make sure pnpm is available for Vite+ package-manager delegation.
+corepack enable
+corepack prepare pnpm@11.2.2 --activate
+
+# 3. Install or update the global Vite+ CLI.
+curl -fsSL https://vite.plus | bash
+exec "$SHELL" -l
+vp help
+
+# 4. Install the frontend dependencies through Vite+.
+vp install
+
+# 5. Validate the migrated frontend.
+vp check
+vp test
+vp build
+```
+
+## Cleanup after migrating from direct nvm/pnpm workflows
+
+Run this once if your checkout has stale Vite/Vitest artifacts from the old toolchain:
+
+```bash
+cd /path/to/Lumilio-Photos/web
+
+# Remove installed packages and generated frontend output.
+rm -rf node_modules dist coverage .vite .vitest
+
+# Optional: prune pnpm's global content-addressable store.
+pnpm store prune
+
+# Optional: clear Vite+ caches if an alpha upgrade behaves oddly.
+rm -rf ~/.vite-plus/cache
+
+# Rehydrate with the Vite+ wrapper.
+vp install
+```
+
+You do **not** need to uninstall nvm or pnpm. Vite+ can manage Node versions itself, but keeping nvm installed is harmless for developers who also work on non-Vite+ projects. Prefer entering this repo with `nvm use` (or `vp env`, once you choose to let Vite+ own Node switching globally) and then run frontend commands through `vp`.
+
+## Command mapping
+
+| Old command | New command |
+| --- | --- |
+| `pnpm install` | `vp install` |
+| `pnpm dev` / `vite` | `vp dev` |
+| `pnpm build` / `vite build` | `vp build` |
+| `pnpm preview` / `vite preview` | `vp preview` |
+| `pnpm lint` / `oxlint` | `vp lint` |
+| `pnpm lint:fix` / `oxlint --fix` | `vp lint --fix` |
+| `pnpm type-check` | `vp check --no-fmt --no-lint` |
+| `pnpm test` / `vitest` | `vp test` |
+| `pnpm test:watch` / `vitest --watch` | `vp test watch` |
+| `pnpm test:coverage` / `vitest run --coverage` | `vp test run --coverage` |
+
+For full-stack local development from the repository root, keep using:
+
+```bash
+make setup
+make dev
+```
+
+`make setup` now installs frontend dependencies through `vp install`, and `make web-dev` starts the frontend with `vp dev --host --port 6657`.

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -74,7 +74,7 @@ Current canonical example: assets domain store at `web/src/features/assets/asset
 ## 4. Frontend Stack Baseline
 
 - React 19 + TypeScript 5
-- Vite 7
+- Vite+ alpha (Vite 8 core)
 - React Router 7
 - TanStack Query 5
 - Zustand 5 + immer
@@ -105,9 +105,9 @@ Current canonical example: assets domain store at `web/src/features/assets/asset
 
 From `web/` run:
 
-1. `pnpm type-check`
-2. `pnpm lint`
-3. `pnpm test` (when behavior changes or bug fix touches logic)
+1. `vp check --no-fmt --no-lint`
+2. `vp lint`
+3. `vp test` (when behavior changes or bug fix touches logic)
 
 If backend contract changed, also ensure `make dto` has been run from repo root.
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,8 +1,16 @@
 # Build React app stage
-FROM node:23.11.1-alpine as build
+FROM node:23.11.1-bookworm-slim as build
 
-# Install pnpm
-RUN npm install -g pnpm
+# Install Vite+ and keep pnpm available for package-manager delegation.
+RUN corepack enable \
+    && corepack prepare pnpm@latest --activate \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl \
+    && curl -fsSL https://vite.plus | bash \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+ENV PATH="/root/.vite-plus/bin:${PATH}"
 
 WORKDIR /app
 
@@ -12,10 +20,10 @@ ARG VITE_PLUGIN_CDN_ORIGIN=https://cdn.lumilio.org
 ARG VITE_STUDIO_PLUGIN_RUNTIME_ENABLED=true
 
 # Copy package.json and pnpm-lock.yaml files
-COPY web/package.json web/pnpm-lock.yaml ./
+COPY web/package.json web/pnpm-lock.yaml web/pnpm-workspace.yaml ./
 
 # Install dependencies
-RUN pnpm install --frozen-lockfile
+RUN vp install
 
 # Copy frontend source code
 COPY web/ ./
@@ -29,7 +37,7 @@ RUN printf '%s\n' \
     > .env
 
 # Build the application
-RUN pnpm run build
+RUN vp build
 
 # Production stage
 FROM nginx:alpine

--- a/web/README.md
+++ b/web/README.md
@@ -5,44 +5,44 @@ The modern, high-performance web interface for Lumilio Photos, built with React,
 ## Tech Stack
 
 - **Framework:** [React 19](https://react.dev/)
-- **Build Tool:** [Vite](https://vitejs.dev/)
+- **Build Toolchain:** [Vite+](https://viteplus.dev/) (Vite 8 core)
 - **Language:** [TypeScript](https://www.typescriptlang.org/)
 - **Styling:** [Tailwind CSS](https://tailwindcss.com/) & [DaisyUI](https://daisyui.com/)
 - **State Management:** [Zustand](https://zustand-demo.pmnd.rs/) & [TanStack Query](https://tanstack.com/query/latest)
 - **Performance:** [WebAssembly (WASM)](https://webassembly.org/) & [Web Workers](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API)
 - **Routing:** [React Router 7](https://reactrouter.com/)
-- **Testing:** [Vitest](https://vitest.dev/)
+- **Testing:** Vite+ test runner (Vitest-compatible APIs)
 
 ## Getting Started
 
 ### Prerequisites
 
 - [Node.js](https://nodejs.org/) (version specified in `.nvmrc`)
-- [pnpm](https://pnpm.io/) (recommended)
+- [Vite+ `vp`](https://viteplus.dev/) (delegates installs through pnpm)
 
 ### Installation
 
 ```bash
-pnpm install
+vp install
 ```
 
 ### Development
 
 ```bash
-pnpm dev
+vp dev
 ```
 
 ### Build
 
 ```bash
-pnpm build
+vp build
 ```
 
 ### Other Scripts
 
-- `pnpm lint`: Run oxlint for fast linting.
-- `pnpm type-check`: Run TypeScript type checking.
-- `pnpm test`: Run unit tests with Vitest.
+- `vp lint`: Run Oxlint through Vite+.
+- `vp check --no-fmt --no-lint`: Run TypeScript type checking through Vite+.
+- `vp test`: Run unit tests through Vite+.
 
 ## Project Structure
 
@@ -67,12 +67,12 @@ The project follows a feature-based and modular architecture:
 
 ## Testing
 
-We use Vitest for unit and integration testing.
+We use the Vite+ test command for unit and integration testing.
 
 ```bash
-pnpm test          # Run tests
-pnpm test:ui       # Run tests with UI
-pnpm test:coverage # Generate coverage report
+vp test                # Run tests
+vp test --ui           # Run tests with UI
+vp test run --coverage # Generate coverage report
 ```
 
 

--- a/web/package.json
+++ b/web/package.json
@@ -4,16 +4,19 @@
     "version": "0.0.0",
     "type": "module",
     "scripts": {
-        "dev": "vite",
-        "build": "vite build",
-        "lint": "oxlint",
-        "lint:fix": "oxlint --fix",
-        "type-check": "tsc -p tsconfig.app.json --noEmit",
-        "preview": "vite preview",
-        "test": "vitest",
-        "test:coverage": "vitest run --coverage",
-        "test:watch": "vitest --watch",
-        "test:ui": "vitest --ui"
+        "dev": "vp dev",
+        "build": "vp build",
+        "lint": "vp lint",
+        "lint:fix": "vp lint --fix",
+        "type-check": "vp check --no-fmt --no-lint",
+        "check": "vp check",
+        "fmt": "vp fmt",
+        "fmt:fix": "vp fmt . --write",
+        "preview": "vp preview",
+        "test": "vp test",
+        "test:coverage": "vp test run --coverage",
+        "test:watch": "vp test watch",
+        "test:ui": "vp test --ui"
     },
     "dependencies": {
         "@immich/justified-layout-wasm": "^0.4.3",
@@ -70,7 +73,6 @@
         "@types/react-syntax-highlighter": "^15.5.13",
         "@vitejs/plugin-react": "^5.1.2",
         "@vitest/browser": "^4.0.18",
-        "@vitest/browser-preview": "^4.0.18",
         "@vitest/coverage-istanbul": "^4.0.18",
         "@vitest/coverage-v8": "4.1.5",
         "@vitest/ui": "^4.0.18",
@@ -84,12 +86,12 @@
         "i18next-cli": "^1.58.0",
         "openapi-typescript": "^7.13.0",
         "oxlint": "^1.39.0",
-        "rolldown-vite": "^7.0.12",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.39.0",
-        "vite": "^7.3.1",
+        "vite": "npm:@voidzero-dev/vite-plus-core@latest",
         "vite-plugin-top-level-await": "^1.5.0",
         "vite-plugin-wasm": "^3.4.1",
-        "vitest": "^4.0.18"
+        "vitest": "npm:@voidzero-dev/vite-plus-test@latest",
+        "vite-plus": "^0.1.22"
     }
 }

--- a/web/pnpm-workspace.yaml
+++ b/web/pnpm-workspace.yaml
@@ -2,3 +2,8 @@ allowBuilds:
   '@parcel/watcher': true
   '@swc/core': true
   esbuild: true
+
+# Route transitive Vite/Vitest consumers through the Vite+ alpha packages.
+overrides:
+  vite: npm:@voidzero-dev/vite-plus-core@latest
+  vitest: npm:@voidzero-dev/vite-plus-test@latest

--- a/web/setup.happy-dom.ts
+++ b/web/setup.happy-dom.ts
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom/vitest";
-import { afterEach, vi } from "vitest";
+import { afterEach, vi } from "vite-plus/test";
 
 class MemoryStorage implements Storage {
   private store = new Map<string, string>();

--- a/web/setup.node.ts
+++ b/web/setup.node.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, test, vi } from 'vite-plus/test';
 
 // Setup global mocks and test environment for Node
 beforeEach(() => {

--- a/web/src/components/PhotoPicker.test.tsx
+++ b/web/src/components/PhotoPicker.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, render, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import type { Asset } from "@/lib/assets/types";
 import PhotoPicker from "./PhotoPicker";
 

--- a/web/src/config/retryTasks.test.ts
+++ b/web/src/config/retryTasks.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "vite-plus/test";
 import {
   getRetryTasksByCategoryForAssetType,
   isRetryTaskSupportedForAssetType,

--- a/web/src/features/assets/assets.store.test.ts
+++ b/web/src/features/assets/assets.store.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "vite-plus/test";
 import { createAssetsStore } from "./assets.store";
 
 describe("createAssetsStore", () => {

--- a/web/src/features/assets/components/page/FullScreen/FullScreenCarousel/fieldGuide.test.ts
+++ b/web/src/features/assets/components/page/FullScreen/FullScreenCarousel/fieldGuide.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "vite-plus/test";
 import {
   formatSpeciesScore,
   getSpeciesScorePercent,

--- a/web/src/features/assets/components/shared/StackCarouselOverlay.test.tsx
+++ b/web/src/features/assets/components/shared/StackCarouselOverlay.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import type { Asset } from "@/lib/assets/types";
 import StackCarouselOverlay from "./StackCarouselOverlay";
 

--- a/web/src/features/assets/components/shared/StackedThumbnail.test.tsx
+++ b/web/src/features/assets/components/shared/StackedThumbnail.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import type { Asset } from "@/lib/assets/types";
 import StackedThumbnail from "./StackedThumbnail";
 

--- a/web/src/features/assets/hooks/useStackCarouselAssets.test.ts
+++ b/web/src/features/assets/hooks/useStackCarouselAssets.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi, beforeEach } from "vite-plus/test";
 import type { Asset, StackMemberDTO } from "@/lib/assets/types";
 import client from "@/lib/http-commons/client";
 import {

--- a/web/src/features/assets/utils/assetGroups.test.ts
+++ b/web/src/features/assets/utils/assetGroups.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "vite-plus/test";
 import {
   flattenAssetGroups,
   formatAssetGroupLabel,

--- a/web/src/features/assets/utils/browseItems.test.ts
+++ b/web/src/features/assets/utils/browseItems.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "vite-plus/test";
 import type { Asset } from "@/lib/assets/types";
 import type { AssetGroup } from "@/features/assets/types/assets.type";
 import {

--- a/web/src/features/settings/settings.persistence.test.ts
+++ b/web/src/features/settings/settings.persistence.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import type { SettingsState } from "./settings.type.ts";
 import {
   persistSettingsState,

--- a/web/src/lib/utils/mediaTypes.test.ts
+++ b/web/src/lib/utils/mediaTypes.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "vite-plus/test";
 
 import type { Asset } from "@/lib/http-commons";
 import { isAudio, isPhoto, isRawPhoto, isVideo } from "./mediaTypes";

--- a/web/src/lib/utils/performancePreferences.test.ts
+++ b/web/src/lib/utils/performancePreferences.test.ts
@@ -1,5 +1,5 @@
 import { renderHook, act } from "@testing-library/react";
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vite-plus/test";
 import {
   PerformancePreferencesManager,
   PerformanceProfile,

--- a/web/src/lib/utils/smartBatchSizing.test.ts
+++ b/web/src/lib/utils/smartBatchSizing.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vite-plus/test';
 import { 
   SmartBatchSizer, 
   ProcessingPriority, 

--- a/web/src/lib/utils/validate-file.test.ts
+++ b/web/src/lib/utils/validate-file.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "vite-plus/test";
 
 import { validateFile } from "./validate-file";
 

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -1,4 +1,4 @@
-/// <reference types="vite/client" />
+/// <reference types="vite-plus/client" />
 
 interface ImportMetaEnv {
   readonly VITE_API_URL?: string;

--- a/web/src/workers/hash.test.ts
+++ b/web/src/workers/hash.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vite-plus/test';
 import { AppWorkerClient, SingleHashResult } from './workerClient';
 
 describe('Hash Worker Performance (Final Strategy)', () => {

--- a/web/tsconfig.app.json
+++ b/web/tsconfig.app.json
@@ -22,7 +22,7 @@
         "paths": {
             "@/*": ["./src/*"]
         },
-        "types": ["vite/client", "vitest/globals", "@testing-library/jest-dom"]
+        "types": ["vite-plus/client", "vite-plus/test/globals", "@testing-library/jest-dom"]
     },
     "include": ["src"]
 }

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,11 +1,13 @@
-/// <reference types="vitest" />
-import { defineConfig } from "vitest/config";
+import { defineConfig } from "vite-plus";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import wasm from "vite-plugin-wasm";
-import path from "path";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import topLevelAwait from "vite-plugin-top-level-await";
-import { preview } from "@vitest/browser-preview";
+import { preview } from "vite-plus/test/browser-preview";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const browserTestsEnabled = process.env.VITEST_BROWSER === "true";
 const testProjects = [
@@ -54,7 +56,7 @@ export default defineConfig({
   plugins: [react(), tailwindcss(), wasm(), topLevelAwait()],
 
   build: {
-    target: 'esnext',
+    target: "esnext",
   },
 
   worker: {
@@ -64,6 +66,24 @@ export default defineConfig({
 
   test: {
     projects: testProjects,
+  },
+
+  lint: {
+    ignorePatterns: ["dist/**", "coverage/**"],
+    options: {
+      typeAware: true,
+      typeCheck: true,
+    },
+  },
+
+  fmt: {
+    semi: true,
+    singleQuote: false,
+  },
+
+  staged: {
+    "*.{js,jsx,ts,tsx}": "vp check --fix",
+    "*.{css,scss,json,md,yml,yaml}": "vp fmt . --write",
   },
 
   optimizeDeps: {


### PR DESCRIPTION
### Motivation

- Replace the project's direct Vite/Vitest/pnpm workflows with the Vite+ (`vp`) alpha CLI to prepare for Vite 8-based tooling and a single `vp` developer surface. 
- Ensure local dev, CI, and container builds use the same `vp` command and provide migration and cleanup guidance for existing `nvm`/`pnpm` setups.

### Description

- Switched frontend npm scripts in `web/package.json` from `vite`/`vitest`/`pnpm` commands to the `vp` command surface and added `vite-plus` dev dependency shims for `vite` and `vitest`. 
- Updated `web/vite.config.ts` to import from `vite-plus`, use `vite-plus/test/browser-preview` for browser testing, add `lint`/`fmt`/`staged` blocks, and adjust Node ESM helpers (`fileURLToPath`).
- Replaced Vitest imports/usages with `vite-plus/test` across test setup and test files, and updated TypeScript test/client typings to `vite-plus` entries (`web/tsconfig.app.json`, `web/src/vite-env.d.ts`).
- Aligned build/dev tooling: `Makefile` now uses `vp` for `setup` and `web-dev`, `web/Dockerfile` and `.devcontainer/Dockerfile` install the Vite+ CLI and run `vp install` / `vp build`, and devcontainer metadata/aliases were updated accordingly. 
- Added `web/pnpm-workspace.yaml` overrides to route transitive `vite`/`vitest` consumers to Vite+ alpha packages and added `docs/development/vite-plus.md` with local setup/cleanup and command mappings.

### Testing

- Ran `git diff --check` to validate no whitespace or simple diff issues and it completed without errors. 
- Validated JSON parsing of modified files with `node -e "JSON.parse(require('fs').readFileSync('web/package.json','utf8')); JSON.parse(require('fs').readFileSync('.devcontainer/devcontainer.json','utf8').replace(/\/\/.*$/mg,'')); console.log('json ok')"` and it succeeded. 
- Attempted `cd web && vp --version` which could not run in this environment because the Vite+ installer/`vp` CLI is not available in the current container (environment limitation). 
- Attempted dependency/resolution and type checks such as `pnpm install --lockfile-only --ignore-scripts` and `pnpm exec tsc -p tsconfig.app.json --noEmit`, but these were interrupted by registry resolution retries and terminated due to network/registry access limits in this environment, so they did not complete successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d717da28c832197448c166a388444)