### PR TITLE
fix(desktop): cgo libraw flag, PG relocation + contrib, resource fetch

### DIFF
--- a/.github/workflows/build-postgres.yml
+++ b/.github/workflows/build-postgres.yml
@@ -39,6 +39,13 @@ jobs:
           ./configure --prefix="$DIST" --without-readline --without-zlib --without-icu
           make -j"$(sysctl -n hw.ncpu)"
           make install
+          # Contrib extensions the schema requires (core `make install` omits
+          # contrib): pgcrypto (CREATE EXTENSION pgcrypto in the first migration)
+          # and pg_trgm (trigram filename search). Build only these two to avoid
+          # contrib modules that need extra deps (openssl/uuid). pgcrypto builds
+          # without OpenSSL using its internal implementations.
+          make -C contrib/pgcrypto install
+          make -C contrib/pg_trgm install
 
       - name: Build pgvector ${{ inputs.pgvector_version }}
         run: |

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,14 @@ GO := go
 VP := vp
 DOCKER := docker
 
+# Homebrew's libraw_r.pc emits `-Xpreprocessor -fopenmp`, which Go's cgo flag
+# allowlist rejects ("invalid flag in pkg-config --libs: -Xpreprocessor"). Allow
+# it so cgo can build the libraw binding (server/internal/utils/raw) and anything
+# that imports it. Exported so every Go target (server-*, desktop-*) inherits it.
+# Harmless on Linux/CI where the flag isn't present.
+export CGO_LDFLAGS_ALLOW := -Xpreprocessor
+export CGO_CFLAGS_ALLOW := -Xpreprocessor
+
 API_URL ?= http://localhost:6680
 VITE_API_URL ?= $(API_URL)
 

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -70,7 +70,8 @@ LUMILIO_E2E=1 LUMILIO_PG_BIN_DIR=/opt/homebrew/opt/postgresql@14/bin \
 
 ```sh
 brew install vips dylibbundler create-dmg      # build-time deps
-# stage native binaries (see desktop/resources/README.md), then:
+desktop/scripts/fetch-resources.sh             # ffmpeg/ffprobe/exiftool (pinned + sha256)
+# also stage PostgreSQL 16 + pgvector into resources/postgres/16/<platform>/ (from source), then:
 make desktop-build                             # → desktop/build/Lumilio Photos.app
 desktop/scripts/build-macos.sh arm64 --dmg     # also produce a DMG
 ```

--- a/desktop/resources/README.md
+++ b/desktop/resources/README.md
@@ -3,8 +3,12 @@
 The desktop app ships its own copies of the native tools the server needs,
 because a packaged macOS app has no system `PATH` or package manager to rely on.
 These binaries are **large and platform-specific**, so they are not committed to
-git — they are staged here by CI (or manually) before `desktop/scripts/build-macos.sh`
-assembles the `.app` bundle.
+git — they are staged here before `desktop/scripts/build-macos.sh` assembles the
+`.app` bundle.
+
+**Quick start:** `desktop/scripts/fetch-resources.sh` downloads ffmpeg, ffprobe,
+and exiftool at pinned versions with SHA-256 verification (defaults to arm64).
+PostgreSQL is the one piece it does not fetch — see below.
 
 Expected layout (per architecture, `darwin-arm64` and/or `darwin-amd64`):
 
@@ -15,11 +19,18 @@ resources/
 │   ├── lib/        (incl. pgvector: vector.dylib under lib/postgresql)
 │   └── share/postgresql/
 ├── ffmpeg/
-│   ├── ffmpeg      static build (BtbN / evermeet.cx)
-│   └── ffprobe
+│   ├── ffmpeg      native static build (arm64)
+│   └── ffprobe     native static build (arm64)
 └── exiftool/
-    └── exiftool    official macOS standalone (bundles its own Perl)
+    ├── exiftool    Perl script (EXIFTOOL_PATH points here)
+    └── lib/        ExifTool's Perl modules — MUST sit next to the script
 ```
+
+> exiftool is a **Perl script**, not a self-contained binary: it runs on macOS's
+> system Perl (`/usr/bin/perl`, present but deprecated by Apple). The `lib/`
+> directory must stay beside the `exiftool` script — the script locates its
+> modules relative to itself. If Apple ever removes system Perl, a Perl
+> interpreter would need to be bundled too.
 
 The supervisor resolves these at runtime relative to the bundle's `Resources`
 directory (`ResourcesDir()` in `supervisor/resources.go`). When a tool is absent
@@ -28,10 +39,21 @@ directory (`ResourcesDir()` in `supervisor/resources.go`). When a tool is absent
 
 ## Where the binaries come from
 
-- **PostgreSQL 16 + pgvector**: built from source in CI — see
-  `.github/workflows/build-postgres.yml`.
-- **ffmpeg / ffprobe**: a static macOS build (~70-80MB) with VideoToolbox.
-- **exiftool**: the official macOS standalone distribution (~6MB).
+`fetch-resources.sh` pins the exact URLs + SHA-256 for ffmpeg/ffprobe/exiftool;
+bump the pins (or override via env) when you update versions.
+
+- **PostgreSQL 16 + pgvector**: built from source — see
+  `.github/workflows/build-postgres.yml`. Not fetched by `fetch-resources.sh`,
+  because Homebrew/prebuilt PostgreSQL is not relocatable (absolute-path dylib
+  links + baked-in paths break when moved into the bundle).
+- **ffmpeg / ffprobe**: native static macOS builds. arm64 from
+  [osxexperts.net](https://www.osxexperts.net) (`ffmpeg<ver>arm.zip` /
+  `ffprobe<ver>arm.zip`); Intel from [evermeet.cx](https://evermeet.cx) (override
+  the URLs + checksums for an amd64 bundle). Each zip's payload is a single
+  self-contained binary (no dylibbundler needed). ~50MB each.
+- **exiftool**: the `Image-ExifTool-<ver>.tar.gz` Perl distribution from
+  [exiftool.org](https://exiftool.org) (the `exiftool` script + `lib/`), not the
+  `.pkg` installer. ~7MB.
 - **libvips + its dependency tree**: not staged here. `dylibbundler` collects it
   from the build host into `Contents/Frameworks/` during `build-macos.sh`
   (`brew install vips dylibbundler` first). libraw rides along as a libvips

--- a/desktop/scripts/build-macos.sh
+++ b/desktop/scripts/build-macos.sh
@@ -19,6 +19,11 @@
 #   desktop/scripts/build-macos.sh [arm64|amd64] [--dmg]
 set -euo pipefail
 
+# Homebrew's libraw_r.pc emits `-Xpreprocessor`, which Go's cgo flag allowlist
+# rejects. Allow it so the libraw binding (server/internal/utils/raw) builds.
+export CGO_LDFLAGS_ALLOW="-Xpreprocessor"
+export CGO_CFLAGS_ALLOW="-Xpreprocessor"
+
 ARCH="${1:-arm64}"
 MAKE_DMG="false"
 for arg in "$@"; do

--- a/desktop/scripts/fetch-resources.sh
+++ b/desktop/scripts/fetch-resources.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+#
+# Download the bundled media tools (ffmpeg, ffprobe, exiftool) into
+# desktop/resources/ with pinned versions and SHA-256 verification. PostgreSQL is
+# NOT fetched here — it must be a relocatable from-source build (see
+# .github/workflows/build-postgres.yml and desktop/resources/README.md).
+#
+# Defaults target Apple Silicon (arm64). For Intel, override the URLs and
+# checksums via env, e.g.:
+#   FFMPEG_URL=https://www.osxexperts.net/ffmpeg81intel.zip \
+#   FFMPEG_SHA256=<intel-binary-sha256> ... desktop/scripts/fetch-resources.sh
+#
+# Re-running is safe: an already-present, checksum-matching binary is skipped.
+set -euo pipefail
+
+# --- Pinned sources (override via env to bump versions / switch arch) ----------
+FFMPEG_URL="${FFMPEG_URL:-https://www.osxexperts.net/ffmpeg81arm.zip}"
+FFMPEG_SHA256="${FFMPEG_SHA256:-9a08d61f9328e8164ba560ee7a79958e357307fcfeea6fe626b7d66cdc287028}"
+
+FFPROBE_URL="${FFPROBE_URL:-https://www.osxexperts.net/ffprobe81arm.zip}"
+FFPROBE_SHA256="${FFPROBE_SHA256:-aab17ac7379c1178aaf400c3ef36cdb67db0b75b1a23eeef2cb9f658be8844e6}"
+
+EXIFTOOL_VERSION="${EXIFTOOL_VERSION:-13.59}"
+EXIFTOOL_URL="${EXIFTOOL_URL:-https://exiftool.org/Image-ExifTool-${EXIFTOOL_VERSION}.tar.gz}"
+EXIFTOOL_SHA256="${EXIFTOOL_SHA256:-668ea3acececb7235fbd0f4900e72d5f12c9b07e5c778fd36cb1e9b5828fd65a}"
+
+# ------------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RESOURCES="$(cd "$SCRIPT_DIR/.." && pwd)/resources"
+FFMPEG_DIR="$RESOURCES/ffmpeg"
+EXIFTOOL_DIR="$RESOURCES/exiftool"
+
+TMPROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPROOT"' EXIT
+
+sha256_of() { shasum -a 256 "$1" | awk '{print $1}'; }
+
+verify() { # file expected
+  local got
+  got="$(sha256_of "$1")"
+  if [ "$got" != "$2" ]; then
+    echo "ERROR: checksum mismatch for $(basename "$1")" >&2
+    echo "  expected $2" >&2
+    echo "  got      $got" >&2
+    echo "  (version bumped upstream? update the pinned URL+SHA, or override via env)" >&2
+    exit 1
+  fi
+}
+
+# fetch_static_binary <name> <zip-url> <expected-binary-sha256>
+# Downloads a zip whose payload is a single static binary named <name>, verifies
+# the extracted binary, and installs it into resources/ffmpeg/.
+fetch_static_binary() {
+  local name="$1" url="$2" want="$3"
+  local dest="$FFMPEG_DIR/$name"
+  if [ -f "$dest" ] && [ "$(sha256_of "$dest")" = "$want" ]; then
+    echo "  $name: already present and verified — skipping"
+    return
+  fi
+  echo "  $name: downloading $url"
+  local work="$TMPROOT/$name"
+  mkdir -p "$work"
+  curl -fsSL "$url" -o "$work/payload.zip"
+  unzip -o -j "$work/payload.zip" -d "$work" >/dev/null
+  if [ ! -f "$work/$name" ]; then
+    echo "ERROR: '$name' binary not found inside $url" >&2
+    exit 1
+  fi
+  verify "$work/$name" "$want"
+  mkdir -p "$FFMPEG_DIR"
+  mv -f "$work/$name" "$dest"
+  chmod +x "$dest"
+  xattr -dr com.apple.quarantine "$dest" 2>/dev/null || true
+  echo "  $name: installed → ${dest#"$RESOURCES"/} ($(sha256_of "$dest" | cut -c1-12)…)"
+}
+
+fetch_exiftool() {
+  if [ -x "$EXIFTOOL_DIR/exiftool" ] && [ -d "$EXIFTOOL_DIR/lib" ]; then
+    echo "  exiftool: already present (exiftool + lib/) — skipping"
+    return
+  fi
+  echo "  exiftool: downloading $EXIFTOOL_URL"
+  local work="$TMPROOT/exiftool"
+  mkdir -p "$work"
+  curl -fsSL "$EXIFTOOL_URL" -o "$work/exiftool.tar.gz"
+  verify "$work/exiftool.tar.gz" "$EXIFTOOL_SHA256"
+  tar xzf "$work/exiftool.tar.gz" -C "$work"
+  local src
+  src="$(find "$work" -maxdepth 1 -type d -name 'Image-ExifTool-*' | head -1)"
+  if [ -z "$src" ] || [ ! -f "$src/exiftool" ] || [ ! -d "$src/lib" ]; then
+    echo "ERROR: extracted exiftool tree (exiftool + lib/) not found" >&2
+    exit 1
+  fi
+  mkdir -p "$EXIFTOOL_DIR"
+  rm -rf "$EXIFTOOL_DIR/lib" "$EXIFTOOL_DIR/exiftool"
+  cp -R "$src/exiftool" "$src/lib" "$EXIFTOOL_DIR/"
+  chmod +x "$EXIFTOOL_DIR/exiftool"
+  xattr -dr com.apple.quarantine "$EXIFTOOL_DIR" 2>/dev/null || true
+  echo "  exiftool: installed → exiftool/{exiftool,lib} (v$EXIFTOOL_VERSION)"
+}
+
+echo "==> Fetching bundled media tools into $RESOURCES"
+fetch_static_binary ffmpeg "$FFMPEG_URL" "$FFMPEG_SHA256"
+fetch_static_binary ffprobe "$FFPROBE_URL" "$FFPROBE_SHA256"
+fetch_exiftool
+
+echo "==> Done. PostgreSQL+pgvector is not fetched here — build it from source"
+echo "    (.github/workflows/build-postgres.yml) into resources/postgres/16/<platform>/."

--- a/desktop/scripts/relocate-postgres.sh
+++ b/desktop/scripts/relocate-postgres.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#
+# Make a from-source PostgreSQL tree relocatable on macOS.
+#
+# PostgreSQL's build bakes the build-machine --prefix into the install names of
+# its client tools (initdb/createdb/pg_isready/pg_dump → libpq.5.dylib) and into
+# the dylib ids themselves. When the tree is copied to another machine (or into
+# the .app bundle) those absolute paths no longer exist and dyld fails with
+# "Library not loaded: <build-prefix>/lib/libpq.5.dylib".
+#
+# This rewrites every absolute reference to a bundled lib into a load-relative
+# path (@executable_path/../lib for bin tools, @loader_path[/..] for dylibs) and
+# ad-hoc re-signs (install_name_tool invalidates signatures; arm64 requires a
+# valid one). Idempotent.
+#
+# Usage: relocate-postgres.sh <postgres platform dir containing bin/ and lib/>
+#   e.g. relocate-postgres.sh desktop/resources/postgres/16/darwin-arm64
+set -euo pipefail
+
+ROOT="$(cd "${1:?usage: relocate-postgres.sh <dir with bin/ and lib/>}" && pwd)"
+[ -d "$ROOT/bin" ] && [ -d "$ROOT/lib" ] || {
+  echo "ERROR: expected bin/ and lib/ under $ROOT" >&2
+  exit 1
+}
+
+have_lib() { find "$ROOT/lib" -name "$1" -print -quit | grep -q .; }
+
+# rel_prefix <file>: the load-relative prefix that points at <ROOT>/lib.
+rel_prefix() {
+  case "$1" in
+    "$ROOT"/bin/*) echo "@executable_path/../lib" ;;
+    "$ROOT"/lib/*/*) echo "@loader_path/.." ;; # e.g. lib/postgresql/<ext>.dylib
+    *) echo "@loader_path" ;;                   # lib/<name>.dylib
+  esac
+}
+
+fix_one() {
+  local f="$1" prefix ref base
+  prefix="$(rel_prefix "$f")"
+  case "$f" in
+    *.dylib) install_name_tool -id "@rpath/$(basename "$f")" "$f" 2>/dev/null || true ;;
+  esac
+  while IFS= read -r ref; do
+    case "$ref" in
+      /*/lib/*.dylib)
+        base="$(basename "$ref")"
+        if have_lib "$base"; then
+          install_name_tool -change "$ref" "$prefix/$base" "$f" 2>/dev/null || true
+        fi
+        ;;
+    esac
+  done < <(otool -L "$f" | awk 'NR>1 {print $1}')
+}
+
+echo "==> Rewriting install names under $ROOT"
+for f in "$ROOT"/bin/*; do
+  [ -f "$f" ] && fix_one "$f"
+done
+while IFS= read -r f; do
+  fix_one "$f"
+done < <(find "$ROOT/lib" -type f -name '*.dylib')
+
+echo "==> Ad-hoc re-signing"
+{ find "$ROOT/lib" -type f -name '*.dylib'; find "$ROOT/bin" -type f; } |
+  while IFS= read -r f; do codesign --force -s - "$f" 2>/dev/null || true; done
+
+echo "==> Done. Verify with: $ROOT/bin/initdb --version"


### PR DESCRIPTION
Unblock the macOS desktop build/run after Homebrew env churn and gaps in the bundled PostgreSQL artifact.

- cgo: Homebrew's libraw_r.pc emits `-Xpreprocessor`, which Go's cgo flag allowlist rejects. Export CGO_LDFLAGS_ALLOW/CGO_CFLAGS_ALLOW=-Xpreprocessor in the Makefile (all Go targets inherit) and build-macos.sh. Harmless on Linux/CI.
- PostgreSQL relocation: add scripts/relocate-postgres.sh. The from-source PG bakes the build-machine prefix into client tools' libpq install names + the dylib ids, so a moved/downloaded artifact fails with "Library not loaded: <prefix>/lib/libpq.5.dylib". Rewrite to @executable_path/@loader_path-relative and ad-hoc re-sign.
- PostgreSQL contrib: build-postgres.yml only installed core + pgvector, so the schema's first migration failed ("extension pgcrypto is not available"). Build contrib/pgcrypto and contrib/pg_trgm too.
- scripts/fetch-resources.sh: download ffmpeg/ffprobe (osxexperts, arm64) and exiftool (exiftool.org) at pinned versions with SHA-256 verification; skips present+verified files. PostgreSQL stays the from-source path.
- docs: correct resources/README (exiftool is a Perl script using system Perl, not a self-contained binary; native arm64 ffmpeg sourcing) and reference the new scripts.