### PR TITLE
docs: align agent harness with current main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ This file is the short entry point for humans and coding agents working in Lumil
 - `server/`: Go API service. Entrypoint is `server/cmd/main.go` (thin); the bootstrap lives in `server/app` (`app.Run(ctx)`); application config is `server/config`; business logic lives in `server/internal/*`; migrations live in `server/migrations`.
 - `web/`: React 19 + TypeScript frontend on Vite+. Feature code lives under `web/src/features/*`; shared pieces live in `web/src/lib`, `web/src/components`, and `web/src/contexts`.
 - `desktop/`: Wails v3 macOS app (separate Go module, `replace server => ../server`). Bundles a private PostgreSQL and runs `server/app` in-process; the React UI is served over HTTP at `localhost:6680`. See `desktop/README.md`.
-- `wasm/`: Rust WebAssembly crates used by the web and plugin flows.
+- `wasm/`: Rust WebAssembly crates for browser-side hashing/export/studio/thumbnail flows; checked-in JS/WASM bundles live under `web/src/wasm`.
 - `docs/`: product/user documentation site. Internal harness docs only belong in `docs/agent/`.
 
 The system is local-first: preserve original media, keep repository/storage semantics explicit, make ML/AI optional, and prefer boring configuration that boots cleanly in Docker and local dev.
@@ -27,6 +27,7 @@ The system is local-first: preserve original media, keep repository/storage sema
 ## Usage Rules
 
 - Use root `make` targets for daily work: `make setup`, `make dev`, `make server-dev`, `make web-dev`, `make test`, `make dto`.
+- Desktop-specific targets: `make desktop-dev`, `make desktop-test`, `make desktop-build`.
 - If you are in a sandbox without host environment, like cloud/container, use `make setup` to set up the local dev environment. Do not use your own cli tooling if possible.
 - Backend quality gate: `make server-test` or `cd server && go test ./...`.
 - Frontend quality gate: `make web-test` or `cd web && vp check --no-fmt --no-lint && vp lint && vp test`.

--- a/docs/agent/BACKEND.md
+++ b/docs/agent/BACKEND.md
@@ -50,10 +50,11 @@ Keep in TOML:
 - storage strategy and duplicate handling
 - repository scan cadence
 - geocoding defaults
-- ML task defaults
+- ML task defaults, including zero-shot classification
 - auth token TTLs and WebAuthn defaults
 - transcoding mode
 - Lumen discovery defaults
+- external tool paths under `[tools]` for `exiftool`, `ffmpeg`, and `ffprobe`
 
 `config.ApplyRuntimeEnvDefaults` exists to keep older package-level `os.Getenv` reads working after TOML is parsed. Prefer passing typed config into new code.
 
@@ -62,12 +63,15 @@ Keep in TOML:
 - `internal/api/router.go`: Gin route tree, CORS, auth boundaries.
 - `internal/api/handler`: HTTP handlers and request/response wiring.
 - `internal/api/dto`: API DTO types.
-- `internal/service`: business services for auth, assets, settings, search, locations, faces, species, indexing, duplicate detection, and Lumen/LLM integration.
+- `internal/service`: business services for auth, assets, settings, search, locations, faces, species, indexing, duplicate detection, cloud import, and Lumen/LLM/classifier integration.
 - `internal/processors`: ingest, metadata, thumbnail, transcode, retry, and asset processing tasks.
 - `internal/queue`: River queue setup and worker implementations.
 - `internal/db`: database connection, migrations, generated sqlc repo layer.
 - `internal/storage`: repository manager, staging manager, repository config, scanner.
 - `internal/cloud`: cloud ingest and sync providers.
+- `internal/sourcing`: unified ingest materialization for upload, repository scans, and cloud sync.
+- `internal/classify`: classifier support code shared by API/service paths.
+- `internal/logging`: zap logger setup, stdlib bridge, and repository audit helpers.
 - `internal/agent`: agent service and tools.
 - `internal/utils`: media, hashing, raw, exif, upload, imaging, and support utilities.
 
@@ -107,6 +111,7 @@ Do not hand-edit generated OpenAPI or frontend schema artifacts.
 River workers are registered in `cmd/main.go` and implemented in `internal/queue`. The processing pipeline uses services and processors for:
 
 - asset ingest and discovery
+- cloud import materialization
 - metadata extraction
 - thumbnail generation
 - video/audio transcoding
@@ -114,13 +119,13 @@ River workers are registered in `cmd/main.go` and implemented in `internal/queue
 - repository scans
 - stack and live photo analysis
 - perceptual hashing
-- ML tasks through Lumen
+- ML tasks through Lumen, including BioCLIP, OCR, face, semantic indexing, and zero-shot classifier tagging
 
 ## ML, Lumen, And LLM
 
-Lumen config is loaded by the Lumen SDK during `initMLServices`. ML feature switches are stored in settings and seeded from config on first initialization.
+Lumen config is loaded by the Lumen SDK during `initMLServices`. ML feature switches are stored in settings and seeded from config on first initialization, including the zero-shot classifier toggle.
 
-LLM settings are represented by `config.LLMConfig`, persisted through the settings service, and validated through `internal/llm`.
+LLM settings are represented by `config.LLMConfig`, persisted through the settings service, and validated through `internal/llm`. Zero-shot classifier preview is exposed through `/api/v1/classifiers/preview` and backed by the classifier service.
 
 The app should remain useful when ML/LLM features are disabled.
 

--- a/docs/agent/FRONTEND.md
+++ b/docs/agent/FRONTEND.md
@@ -64,7 +64,7 @@ vp exec i18next-cli status
 - `src/wasm`: checked-in generated/bundled WASM support code.
 - `src/workers`: browser worker entry points and worker tests.
 
-Current feature areas include assets, auth, collections, home, Lumilio chat, manage/upload, monitor, people, settings, studio, updates, and users.
+Current feature areas include assets, auth, collections, home, Lumilio chat, manage, monitor, people, portfolio, settings, studio, upload, updates, and users.
 
 ## API Contract
 
@@ -114,16 +114,21 @@ Main app routes are rendered inside the shell with `NavBar`, `SideBar`, a scroll
 
 - `/`
 - `/assets`
+- `/assets/:assetId`
 - `/collections`
 - `/collections/albums`
 - `/collections/map`
+- `/collections/places/:tripId`
 - `/collections/people`
 - `/collections/utilities/duplicates`
+- `/collections/utilities/:classifierSlug`
 - `/people/:personId`
 - `/manage`
 - `/studio`
 - `/server-monitor`
 - `/lumilio`
+
+Legacy compatibility routes also redirect `/upload-photos` to `/manage`.
 
 ## Browser Runtime
 

--- a/docs/agent/architecture.md
+++ b/docs/agent/architecture.md
@@ -13,13 +13,14 @@ This is the compact system map for agents. Keep details here stable and useful; 
 
 - `server/cmd/main.go`: thin entrypoint (signal handling + normal TOML/env config load) that calls `server/app`.
 - `server/app`: the only server runtime — logging, migrations, queue workers, router, repository bootstrap, SPA serving, and graceful shutdown via `Run(ctx, cfg)`. Imported by the CLI and, in-process, by the desktop supervisor.
-- `server/config`: single config schema/defaults boundary, including normal TOML/env loading and `NewDesktopConfig` for the desktop host. Desktop may write a generated TOML debug copy, but runtime uses typed config.
+- `server/config`: single config schema/defaults boundary, including normal TOML/env loading, external tool paths, and `NewDesktopConfig` for the desktop host. Desktop may write a generated TOML debug copy, but runtime uses typed config.
 - `server/internal/api/router.go`: route map, auth boundaries, CORS.
 - `server/internal/api/handler`: HTTP request/response layer.
-- `server/internal/service`: business logic, auth, settings, indexing, search, ML adapters.
+- `server/internal/service`: business logic, auth, settings, indexing, search, cloud import, and ML/classifier adapters.
 - `server/internal/processors`: ingest, metadata, thumbnail, transcode pipeline.
 - `server/internal/queue`: River jobs and workers.
 - `server/internal/storage`: repository layout, staging, scanner, repository config.
+- `server/internal/sourcing`: unified ingest materialization for upload, scan, and cloud flows.
 - `server/internal/db` and `server/migrations`: database runtime and schema changes.
 
 ## Frontend
@@ -28,7 +29,8 @@ This is the compact system map for agents. Keep details here stable and useful; 
 - `web/src/lib/http-commons`: generated OpenAPI types and typed API client.
 - `web/src/contexts`: cross-cutting app state.
 - `web/src/components`: reusable UI components.
-- `web/src/wasm` and workers: compute-heavy browser paths.
+- `web/src/wasm` and `web/src/workers`: checked-in `blake3`/`studio` browser bundles and worker entry points for compute-heavy paths.
+- `wasm/*`: Rust source crates for `blake3-wasm`, `studio-wasm`, `thumbnail-wasm`, and `export-wasm`.
 
 ## Contracts
 

--- a/docs/agent/exec-plans/active/desktop-wails-v3.md
+++ b/docs/agent/exec-plans/active/desktop-wails-v3.md
@@ -77,7 +77,8 @@ desktop/                              # New top-level directory
 │   ├── config.go                     # Desktop settings + secret helpers
 │   ├── lock.go                       # flock single-instance guard
 │   ├── paths.go                      # OS-specific app data paths
-│   └── quarantine_darwin.go          # xattr cleanup (build-tagged)
+│   ├── quarantine_darwin.go          # xattr cleanup (build-tagged)
+│   └── resources.go                  # Bundled resource resolution / dev overrides
 ├── resources/
 │   └── postgres/16/
 │       ├── darwin-arm64/             # Apple Silicon
@@ -86,7 +87,6 @@ desktop/                              # New top-level directory
 │       │   ├── lib/
 │       │   └── share/postgresql/
 │       └── darwin-amd64/             # Intel (if supported)
-└── wails.json
 ```
 
 **No `bin/river`** in resources — River migrations already use Go API (`rivermigrate`).
@@ -94,14 +94,13 @@ desktop/                              # New top-level directory
 ### Go Module Structure
 
 ```
-# Root go.work
-go 1.24
-
-use (
-    ./server
-    ./desktop
-)
+desktop/go.mod
+  require server
+  replace server => ../server
 ```
+
+`go.work` is intentionally not committed here; the `replace` directive is the
+load-bearing local/CI wiring.
 
 ## Runtime Data Directory
 
@@ -371,7 +370,7 @@ bundle. They split into two integration models with very different bundling work
 |---|---|---|---|
 | **libvips** | cgo compile-time link (`govips/v2`) | `internal/utils/imaging/process.go` | dylib tree in `Contents/Frameworks/` |
 | **libraw** | NOT called directly — libvips' RAW load delegate | (Dockerfile note) | comes free with libvips tree |
-| **exiftool** | subprocess, hardcoded to PATH | `internal/utils/exif/extract.go:222` | standalone dist in `Resources/` |
+| **exiftool** | subprocess, hardcoded to PATH | `internal/utils/exif/extract.go:222` | script + `lib/` staged in `Resources/` |
 | **ffmpeg** | subprocess (transcode) | — | static binary in `Resources/` |
 
 ### Track A — libvips + libraw + dependency tree (linked libs)
@@ -407,8 +406,9 @@ and `internal/utils/exif/utils.go` hardcode `exec.Command(ctx, "exiftool", ...)`
 and `LookPath("exiftool")` against system PATH. Desktop has no system exiftool, so
 the path must become configurable.
 
-- **exiftool**: ship the official macOS standalone build (bundles its own Perl, no
-  system Perl dependency) under `Resources/exiftool/`. ~6MB.
+- **exiftool**: ship the official Perl distribution (`exiftool` script +
+  adjacent `lib/`) under `Resources/exiftool/`. It currently relies on macOS's
+  system Perl at runtime. ~7MB.
 - **ffmpeg**: ship a static build (BtbN / evermeet.cx macOS build) under
   `Resources/ffmpeg/`. ~70-80MB with full codecs. VideoToolbox HW transcode works
   in static builds.

--- a/docs/agent/vite-plus.md
+++ b/docs/agent/vite-plus.md
@@ -9,7 +9,7 @@ Docs are local at `web/node_modules/vite-plus/docs` or online at https://viteplu
 ## Review Checklist
 
 - [ ] Run `vp install` after pulling remote changes and before getting started.
-- [ ] Run `vp check` and `vp test` to format, lint, type check and test changes.
+- [ ] Run the repo gate as documented in `make web-test`: `vp check --no-fmt --no-lint`, `vp lint`, then `vp test`.
 - [ ] Check if there are `vite.config.ts` tasks or `package.json` scripts necessary for validation, run via `vp run <script>`.
 - [ ] If setup, runtime, or package-manager behavior looks wrong, run `vp env doctor` and include its output when asking for help.
 


### PR DESCRIPTION
## Summary
- align AGENTS.md and docs/agent with the current main codebase after bootstrap audit
- document current frontend routes/features, backend zero-shot classifier and tool-path behavior, and desktop/wasm details
- fix stale Vite+ and desktop exec-plan notes so harness guidance matches verified runtime behavior

## Validation
- git fetch origin main
- make server-test
- cd web && vp check --no-fmt --no-lint
- cd web && vp lint
- cd web && vp test
