### PR TITLE
fix(release): mount GitHub Packages npm token as BuildKit secret for …

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -63,6 +63,10 @@ jobs:
                   platforms: linux/${{ matrix.arch }}
                   build-args: |
                       VERSION=${{ github.ref_name }}
+                  # Only web/Dockerfile mounts this (GitHub Packages npm auth
+                  # for @edwinzhancn/docts); unused by server/db builds.
+                  secrets: |
+                      npmrc=//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}
                   outputs: type=image,name=${{ env.IMAGE_BASE }}/lumilio-${{ matrix.image }},push-by-digest=true,name-canonical=true,push=true
                   cache-from: type=gha,scope=${{ matrix.image }}-${{ matrix.arch }}
                   cache-to: type=gha,mode=max,scope=${{ matrix.image }}-${{ matrix.arch }}

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -25,8 +25,12 @@ ARG VERSION=dev
 # Copy package.txt and pnpm-lock.yaml files
 COPY web/package.json web/pnpm-lock.yaml web/pnpm-workspace.yaml ./
 
-# Install dependencies
-RUN vp install
+# Install dependencies. @edwinzhancn/docts resolves from GitHub Packages,
+# which requires a token even for public packages; mount it as a BuildKit
+# secret so it never lands in an image layer:
+#   docker build --secret id=npmrc,src=<file with //npm.pkg.github.com/:_authToken=...> ...
+# (CI passes GITHUB_TOKEN this way; without the secret the fetch 401s.)
+RUN --mount=type=secret,id=npmrc,target=/root/.npmrc vp install
 
 # Copy frontend source code
 COPY web/ ./


### PR DESCRIPTION
…web image

The web pnpm lockfile pins @edwinzhancn/docts to npm.pkg.github.com, which rejects unauthenticated fetches even for public packages. Mount the token as a build secret (never persisted in layers); CI feeds GITHUB_TOKEN.