### PR TITLE
feat(release): macOS desktop DMG workflow + Windows PG bundle

### DIFF
--- a/.github/workflows/build-postgres.yml
+++ b/.github/workflows/build-postgres.yml
@@ -16,9 +16,20 @@ on:
       pgvector_version:
         description: pgvector version (git tag)
         default: "v0.8.0"
+  # Callable from the desktop release workflows so the PG artifacts are built
+  # fresh within the same run (artifact retention is short).
+  workflow_call:
+    inputs:
+      pg_version:
+        type: string
+        default: "17.5"
+      pgvector_version:
+        type: string
+        default: "v0.8.0"
 
 jobs:
   build:
+    name: macOS (${{ matrix.platform }})
     strategy:
       fail-fast: false
       matrix:
@@ -77,5 +88,59 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: postgres-${{ matrix.platform }}
+          path: postgres/
+          retention-days: 7
+
+  # Windows bundle: EDB publishes official relocatable binaries (zip), so we
+  # only compile pgvector against them (pg_trgm ships in the zip already).
+  build-windows:
+    name: Windows (windows-amd64)
+    runs-on: windows-2025
+    steps:
+      - name: Download PostgreSQL ${{ inputs.pg_version }} binaries (EDB)
+        shell: pwsh
+        run: |
+          $ver = "${{ inputs.pg_version }}-1"
+          $url = "https://get.enterprisedb.com/postgresql/postgresql-$ver-windows-x64-binaries.zip"
+          Invoke-WebRequest -Uri $url -OutFile pg.zip
+          Expand-Archive pg.zip -DestinationPath .
+          # Layout after extraction: .\pgsql\{bin,lib,share,include,...}
+
+      - name: Build pgvector ${{ inputs.pgvector_version }}
+        shell: pwsh
+        run: |
+          git clone --branch "${{ inputs.pgvector_version }}" --depth 1 https://github.com/pgvector/pgvector.git
+
+      - uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Compile pgvector (nmake)
+        shell: cmd
+        working-directory: pgvector
+        run: |
+          set "PGROOT=%GITHUB_WORKSPACE%\pgsql"
+          nmake /F Makefile.win
+          nmake /F Makefile.win install
+
+      - name: Stage bundle layout
+        shell: pwsh
+        run: |
+          $out = "postgres/17/windows-amd64"
+          New-Item -ItemType Directory -Force -Path $out | Out-Null
+          Copy-Item -Recurse pgsql/bin, pgsql/lib, pgsql/share $out
+          # Slim: keep only the binaries the supervisor uses (plus the DLLs
+          # they load, which live alongside them in bin).
+          $keep = @('postgres.exe','initdb.exe','pg_ctl.exe','pg_isready.exe',
+                    'createdb.exe','pg_dump.exe','pg_restore.exe','pg_config.exe')
+          Get-ChildItem "$out/bin" -File | Where-Object {
+              $_.Extension -eq '.exe' -and $keep -notcontains $_.Name
+          } | Remove-Item
+          # Sanity: pgvector + pg_trgm extensions present.
+          if (-not (Test-Path "$out/share/extension/vector.control")) { throw "pgvector missing" }
+          if (-not (Test-Path "$out/share/extension/pg_trgm.control")) { throw "pg_trgm missing" }
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: postgres-windows-amd64
           path: postgres/
           retention-days: 7

--- a/.github/workflows/release-desktop-macos.yml
+++ b/.github/workflows/release-desktop-macos.yml
@@ -1,0 +1,125 @@
+name: Release Desktop (macOS)
+
+# Builds the ad-hoc-signed macOS DMG on version tags: fresh relocatable
+# PostgreSQL (called workflow) → staged media tools (fetch-resources.sh) →
+# web SPA → desktop/scripts/build-macos.sh --dmg → GitHub Release asset.
+#
+# Apple Silicon (arm64) only for now: fetch-resources.sh pins arm64
+# ffmpeg/ffprobe builds. Add an amd64 matrix entry once Intel URL+SHA pins
+# exist (runner: macos-15-intel, artifact postgres-darwin-amd64).
+
+on:
+    push:
+        tags:
+            - "v*"
+    workflow_dispatch:
+
+permissions:
+    contents: read
+
+jobs:
+    postgres:
+        uses: ./.github/workflows/build-postgres.yml
+
+    dmg:
+        name: dmg (${{ matrix.arch }})
+        needs: postgres
+        runs-on: ${{ matrix.runner }}
+        permissions:
+            contents: read
+            packages: read
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - arch: arm64
+                      runner: macos-15
+        steps:
+            - uses: actions/checkout@v4
+
+            - uses: actions/setup-go@v5
+              with:
+                  go-version-file: desktop/go.mod
+                  cache-dependency-path: |
+                      desktop/go.sum
+                      server/go.sum
+
+            - name: Install build dependencies
+              run: brew install vips libraw dylibbundler create-dmg
+
+            - name: Enable pnpm via corepack
+              run: corepack enable
+
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 24
+                  cache: pnpm
+                  cache-dependency-path: web/pnpm-lock.yaml
+
+            - name: Install Vite+
+              run: |
+                  curl -fsSL https://vite.plus | bash
+                  echo "$HOME/.vite-plus/bin" >> "$GITHUB_PATH"
+
+            # @edwinzhancn/docts resolves from GitHub Packages (token required).
+            - name: Authenticate GitHub Packages
+              run: echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> ~/.npmrc
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Build web SPA
+              run: cd web && vp install && vp build
+
+            - name: Stage PostgreSQL bundle
+              uses: actions/download-artifact@v4
+              with:
+                  name: postgres-darwin-${{ matrix.arch }}
+                  path: desktop/resources/postgres
+
+            - name: Stage media tools (ffmpeg/ffprobe/exiftool)
+              run: desktop/scripts/fetch-resources.sh
+
+            - name: Build .app and DMG
+              run: |
+                  TAG="${{ github.ref_name }}"
+                  LUMILIO_VERSION="${TAG#v}" desktop/scripts/build-macos.sh ${{ matrix.arch }} --dmg
+
+            - name: Rename DMG for release
+              run: |
+                  mv "desktop/build/Lumilio-Photos-${{ matrix.arch }}.dmg" \
+                     "desktop/build/Lumilio-Photos-${{ github.ref_name }}-macos-${{ matrix.arch }}.dmg"
+
+            - uses: actions/upload-artifact@v4
+              with:
+                  name: dmg-${{ matrix.arch }}
+                  path: desktop/build/Lumilio-Photos-*-macos-${{ matrix.arch }}.dmg
+                  if-no-files-found: error
+
+    release:
+        name: Attach to GitHub Release
+        runs-on: ubuntu-24.04
+        needs: dmg
+        if: startsWith(github.ref, 'refs/tags/')
+        permissions:
+            contents: write
+        steps:
+            - name: Download DMGs
+              uses: actions/download-artifact@v4
+              with:
+                  pattern: dmg-*
+                  path: dist
+                  merge-multiple: true
+
+            - uses: softprops/action-gh-release@v2
+              with:
+                  prerelease: ${{ contains(github.ref_name, '-') }}
+                  fail_on_unmatched_files: true
+                  files: dist/Lumilio-Photos-*.dmg
+                  body: |
+                      ## macOS Desktop (Apple Silicon)
+
+                      1. Download `Lumilio-Photos-${{ github.ref_name }}-macos-arm64.dmg` and drag the app into **Applications**.
+                      2. First launch: the app is ad-hoc signed (not notarized), so approve it once via **System Settings → Privacy & Security → Open Anyway**.
+                      3. Allow the **local network** prompt so Lumen ML servers can be discovered over mDNS (optional — the app works without ML).
+
+                      Linux/Docker images: `ghcr.io/edwinzhancn/lumilio-{server,web,db}` — see `docker-compose.release.yml`.

--- a/desktop/scripts/build-macos.sh
+++ b/desktop/scripts/build-macos.sh
@@ -83,6 +83,13 @@ cat > "$APP/Contents/Info.plist" <<PLIST
   <key>CFBundleVersion</key><string>$VERSION</string>
   <key>LSMinimumSystemVersion</key><string>11.0</string>
   <key>NSHighResolutionCapable</key><true/>
+  <key>LSUIElement</key><true/>
+  <key>NSLocalNetworkUsageDescription</key>
+  <string>Lumilio Photos discovers Lumen ML servers on your local network via mDNS to enable optional AI features (semantic search, face recognition, OCR).</string>
+  <key>NSBonjourServices</key>
+  <array>
+    <string>_lumen._tcp</string>
+  </array>
 </dict>
 </plist>
 PLIST

--- a/site/docs/internal/agent/exec-plans/active/release-cicd.md
+++ b/site/docs/internal/agent/exec-plans/active/release-cicd.md
@@ -42,13 +42,20 @@ Scope: Lumilio-Photos (this repo) + coordination items in Lumen-SDK and Lumen-Hu
 - `docker-compose.release.yml` (GHCR images, `LUMILIO_STORAGE` required, `LUMILIO_VERSION` pin) + `docker-compose.host-mdns.yml` Linux overlay (`network_mode: host` on server, db via `127.0.0.1:5433`, web upstream via host-gateway, needs compose ≥ 2.24 for `!reset`). All three discovery modes documented in the compose header.
 - **Fixed en route**: root `docker-compose.yml` preloaded `pg_textsearch` which the db image never contained — db could not boot; removed. Search actually uses pg_trgm + `to_tsvector('simple')` only, so `lumilio-db` = pgvector base image, and `build-postgres.yml` dropped its pg_textsearch/SCWS/zhparser steps (desktop bundle likewise only needs PG + pgvector).
 
-### W3 — macOS desktop release
-- `release-desktop-macos.yml` on tag: stage PG artifact (from build-postgres.yml), `fetch-resources.sh`, `vp build` SPA, `build-macos.sh {arm64,amd64} --dmg`, ad-hoc sign, upload DMGs to the GitHub Release. Info.plist local-network key (P1). Notarization = future paid-account upgrade.
+### W3 — macOS desktop release — **Done 2026-07-05** (arm64; pending first tag run)
+- `release-desktop-macos.yml` on tag: calls `build-postgres.yml` (`workflow_call` added) for a fresh PG artifact → `fetch-resources.sh` → web SPA (needs GH Packages token for docts) → `build-macos.sh arm64 --dmg` (ad-hoc sign inside) → DMG attached to the GitHub Release with Gatekeeper + local-network instructions.
+- Info.plist now carries `NSLocalNetworkUsageDescription` + `NSBonjourServices _lumen._tcp` + `LSUIElement` (tray-only, matches ActivationPolicyAccessory).
+- amd64 deferred: `fetch-resources.sh` pins arm64 ffmpeg/ffprobe only; add Intel URL+SHA pins + `macos-15-intel` matrix entry when wanted. Notarization = future paid-account upgrade.
 
-### W4 — Windows desktop (largest unknown; run spike first)
-- **Spike (gates the milestone): pg_textsearch + zhparser/SCWS on Windows MSVC.** If not buildable, decide fallback (ship without BM25/zh segmentation on Windows, or WSL-based path, or swap extension).
-- Then: supervisor Windows port (paths, pg_ctl, single-instance, no quarantine step), PG 17 Windows bundle (EDB zip + pgvector build), MSYS2/mingw CGo toolchain for libvips+libraw, ffmpeg/exiftool Windows binaries in fetch-resources, Wails tray on Windows, NSIS installer, SmartScreen doc.
-- Recommendation: release macOS Desktop + Linux Docker as v1.0; Windows Desktop as v1.1 beta channel unless the spike lands quickly.
+### W4 — Windows desktop (unblocked: BM25/zh-seg removal killed the PG spike)
+- ✅ **PG bundle (2026-07-05)**: `build-postgres.yml` `build-windows` job — EDB official binaries zip + pgvector via MSVC nmake; pg_trgm ships in the zip. Artifact `postgres-windows-amd64` matches the supervisor's `GOOS-GOARCH` resource lookup. Verify with a dispatch run.
+- **Supervisor port** (audit 2026-07-05 — smaller than feared; quarantine + resources are already build-tagged):
+  1. `lock_other.go` is an always-error stub → real Windows single-instance lock (`LockFileEx` or exclusive-create pidfile).
+  2. Windows PostgreSQL has **no Unix sockets** → `paths.go` `SocketDir` + `config.NewDesktopConfig` (DB host = socket dir) must switch to TCP `127.0.0.1:<port>` on Windows; `postgres.go` pg_ctl/initdb args likewise.
+  3. `paths.go` app-data root → `%LOCALAPPDATA%\Lumilio Photos` on Windows.
+- **CGo toolchain (main risk now)**: libvips + libraw via MSYS2 mingw-w64 on a windows runner; add an experimental (continue-on-error) CI job to gather signal before committing to it.
+- fetch-resources Windows variants (gyan.dev ffmpeg, exiftool Windows zip), Wails tray on Windows (proven by lumen-gateway), NSIS installer or portable zip, SmartScreen doc.
+- Recommendation stands: v1.0 = macOS Desktop + Linux Docker; Windows = v1.x beta channel.
 
 ### W5 — release checklist (per-release)
 - Lumen-Hub tag published + `manifest.json` reachable; `lumilio.org/lumen/install.{sh,ps1}` worker serving latest.


### PR DESCRIPTION
release-desktop-macos.yml builds the ad-hoc-signed arm64 DMG on v* tags: fresh PG artifact via build-postgres.yml (now workflow_call-able), staged media tools, web SPA, build-macos.sh --dmg, asset attached to the release. Info.plist gains NSLocalNetworkUsageDescription + NSBonjourServices so macOS 15 permits Lumen mDNS discovery, and LSUIElement for the tray-only app. build-postgres.yml adds a windows-amd64 job (EDB binaries + pgvector via MSVC nmake) — the Windows PG spike is moot now that BM25/zh-seg are gone.