### PR TITLE
fix(devcontainer): derive the db bootstrap secret from the repository

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -4,13 +4,25 @@
 name: lumilio-photos-devcontainer
 
 services:
+    # Copies the repository's bootstrap secret into the volume postgres reads it
+    # from. It must *derive* rather than generate: the server reads
+    # server/config/.secrets/db_bootstrap_password (see database.bootstrap_password_file
+    # in server.local.toml), so a secret generated independently here would
+    # initialize postgres with a password the server does not know, and every
+    # connection would fail SASL auth. `make .server-secret` is the one generator.
+    #
+    # The volume exists because a bind mount does not work portably: the host
+    # file is 0600 and owned by the developer, while postgres runs as uid 999
+    # inside the container. It happens to be readable under OrbStack's virtiofs,
+    # but not on Linux.
     secretinit:
-        image: golang:1.25.0-trixie
-        working_dir: /workspace
+        image: alpine:3
         volumes:
             - ..:/workspace:ro
             - db-bootstrap-secret:/secrets
-        command: go run ./server/tools/secretinit /secrets/db_bootstrap_password
+        command: >-
+            sh -c 'install -m 600 /workspace/server/config/.secrets/db_bootstrap_password
+            /secrets/db_bootstrap_password'
 
     db:
         build:
@@ -52,7 +64,10 @@ services:
             - go-mod-cache:/root/go
             - pnpm-store:/root/.local/share/pnpm
             - cargo-cache:/usr/local/cargo/registry
-            - db-bootstrap-secret:/workspace/server/config/.secrets:ro
+        # No db-bootstrap-secret mount: the secret's home is the repository, at
+        # server/config/.secrets, which /workspace already provides read-write.
+        # Mounting the volume over that path would shadow the source with the
+        # derived copy and make `make .server-secret` fail on a read-only file.
         environment:
             CGO_ENABLED: "1"
             GOFLAGS: -buildvcs=false


### PR DESCRIPTION
`make db` could not bring up the database, for two independent reasons.

## The visible failure

`secretinit` ran `go run ./server/tools/secretinit` with `working_dir: /workspace`, but the repository has no top-level `go.mod` — the modules are `server/` and `desktop/`. Go failed with `cannot find main module, but found .git/config in /workspace` before ever reaching the tool.

## The real problem underneath

Fixing the working directory exposed it: `secretinit` **generated its own** random secret into a volume, while the server reads `server/config/.secrets/db_bootstrap_password` (`database.bootstrap_password_file` in `server.local.toml`), generated separately by `make .server-secret`.

Two independent generators, never reconciled. Postgres initialized with a password the server did not know, and every connection failed:

```
failed SASL auth: FATAL: password authentication failed for user "postgres" (SQLSTATE 28P01)
```

The devcontainer masked this by mounting the volume *over* that repository path, so inside the container the two were the same file. Running `make dev` on the host — the documented daily workflow — could never work with a fresh `db_data` volume.

## The fix

The repository file becomes the single source of truth; `make .server-secret` is the one generator. `secretinit` is reduced to copying it into the volume postgres reads.

The volume stays rather than bind-mounting the directory, because a bind mount is not portable: the host file is `0600` and owned by the developer, while postgres runs as uid 999 in the container. It happens to be readable under OrbStack's virtiofs, but would fail on Linux.

The devcontainer's `db-bootstrap-secret:/workspace/server/config/.secrets:ro` mount is removed — with the direction now repo → volume, it would shadow the source with the derived copy and make `make .server-secret` fail on a read-only file.

With no Go left to run, the service drops from `golang:1.25.0-trixie` (1GB) to `alpine:3` (8MB).

## Verification

Wiped both volumes and the local secret, then cold-started from nothing:

- `make db` → healthy
- local and volume secrets byte-identical
- server connects, applies all migrations, reaches `bootstrap phase: fresh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)