### PR TITLE
test: harden video semantic regression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,9 @@ jobs:
             - name: Run Chromium smoke
               run: make web-browser-test
 
+            - name: Run video semantic regression
+              run: make web-video-semantic-test
+
             - name: Capture E2E service logs
               if: failure()
               run: |

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ COMPOSE = $(if $(COMPOSE_BIN),$(COMPOSE_BIN) -f $(COMPOSE_FILE) -p $(COMPOSE_PRO
 
 DB_VOLUME ?= $(COMPOSE_PROJECT)_db_data
 
-.PHONY: setup dev server-dev web-dev test server-test web-test web-browser-test dto db db-reset dev-reset \
+.PHONY: setup dev server-dev web-dev test server-test web-test web-browser-test web-video-semantic-test dto db db-reset dev-reset \
 	desktop-dev desktop-build desktop-test desktop-panel \
 	.server-config .server-secret .web-env
 
@@ -89,6 +89,9 @@ web-test:
 
 web-browser-test:
 	cd $(WEB_DIR) && $(VP) run e2e:seed && $(VP) run test:browser
+
+web-video-semantic-test:
+	cd $(WEB_DIR) && $(VP) run e2e:seed:video-semantic && $(VP) run test:video-semantic
 
 desktop-panel:
 	@echo "==> Building desktop control panel (Svelte, embedded into the Go binary)"

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -5,6 +5,8 @@ services:
         build:
             context: .
             dockerfile: web/e2e/support/fakelumen.Dockerfile
+        ports:
+            - "127.0.0.1:${LUMILIO_E2E_LUMEN_METRICS_PORT:-16658}:50052"
         healthcheck:
             test: ["CMD", "/fakelumen", "-health-check", "127.0.0.1:50051"]
             interval: 1s

--- a/server/internal/api/handler/asset_handler.go
+++ b/server/internal/api/handler/asset_handler.go
@@ -4184,18 +4184,8 @@ func (h *AssetHandler) ReprocessAsset(c *gin.Context) {
 
 	// Validate requested tasks (using queue names as canonical task identifiers)
 	if len(req.Tasks) > 0 {
-		validQueues := map[string]bool{
-			"metadata_asset":   true,
-			"thumbnail_asset":  true,
-			"transcode_asset":  true,
-			"process_semantic": true,
-			"process_bioclip":  true,
-			"process_ocr":      true,
-			"process_face":     true,
-		}
-
 		for _, task := range req.Tasks {
-			if !validQueues[task] {
+			if !isValidReprocessQueue(task) {
 				api.GinBadRequest(c, fmt.Errorf("invalid queue name: %s", task), fmt.Sprintf("Invalid queue name: %s", task))
 				return
 			}
@@ -4372,6 +4362,22 @@ func (h *AssetHandler) ReprocessAsset(c *gin.Context) {
 
 		api.JSONOK(c, response)
 		return
+	}
+}
+
+func isValidReprocessQueue(queue string) bool {
+	switch queue {
+	case "metadata_asset",
+		"thumbnail_asset",
+		"transcode_asset",
+		"process_semantic",
+		"process_bioclip",
+		"process_ocr",
+		"process_face",
+		"process_video_frames":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/server/internal/api/handler/asset_handler_reprocess_test.go
+++ b/server/internal/api/handler/asset_handler_reprocess_test.go
@@ -1,0 +1,25 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsValidReprocessQueue(t *testing.T) {
+	t.Parallel()
+
+	for _, queue := range []string{
+		"metadata_asset",
+		"thumbnail_asset",
+		"transcode_asset",
+		"process_semantic",
+		"process_bioclip",
+		"process_ocr",
+		"process_face",
+		"process_video_frames",
+	} {
+		require.True(t, isValidReprocessQueue(queue), queue)
+	}
+	require.False(t, isValidReprocessQueue("unknown"))
+}

--- a/server/internal/processors/asset_retry.go
+++ b/server/internal/processors/asset_retry.go
@@ -132,7 +132,9 @@ func (ap *AssetProcessor) enqueueRetryTasks(
 	}
 
 	// Enqueue tasks based on queue names (bijection: queue name = task name)
-	// Available queues: metadata_asset, thumbnail_asset, transcode_asset, process_semantic, process_bioclip, process_ocr, process_face
+	// Available queues: metadata_asset, thumbnail_asset, transcode_asset,
+	// process_semantic, process_bioclip, process_ocr, process_face,
+	// process_video_frames
 
 	// Enqueue metadata_asset if requested (all asset types support metadata)
 	if queueSet["metadata_asset"] {

--- a/server/internal/queue/jobs/types.go
+++ b/server/internal/queue/jobs/types.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/rivertype"
 
 	"server/internal/db/dbtypes"
 )
@@ -20,18 +21,27 @@ type ProcessSemanticArgs struct {
 func (ProcessSemanticArgs) Kind() string { return "process_semantic" }
 
 func (ProcessSemanticArgs) InsertOpts() river.InsertOpts {
+	return mlProcessInsertOpts()
+}
+
+func mlProcessInsertOpts() river.InsertOpts {
 	return river.InsertOpts{
 		MaxAttempts: MLProcessMaxAttempts,
 		// Dedupe concurrent reindex/retry fan-out per asset: an equivalent job
-		// still available/running/completed in the table is silently skipped
-		// (Insert returns UniqueSkippedAsDuplicate=true, nil error). Default
-		// ByState includes completed, so overlapping full-rebuild chains collapse
-		// to one job per asset instead of racing the non-transactional OCR/face
-		// save paths. ByArgs also keys on PreprocessVersion, so bumping the
-		// version re-allows a re-run.
+		// still pending or running is silently skipped. Completed jobs are
+		// deliberately excluded: explicit backfill, reset, and retry operations
+		// must be able to process the same asset again inside the five-minute
+		// window. ByArgs also keys on PreprocessVersion where present.
 		UniqueOpts: river.UniqueOpts{
 			ByArgs:   true,
 			ByPeriod: MLProcessUniquePeriod,
+			ByState: []rivertype.JobState{
+				rivertype.JobStateAvailable,
+				rivertype.JobStatePending,
+				rivertype.JobStateRetryable,
+				rivertype.JobStateRunning,
+				rivertype.JobStateScheduled,
+			},
 		},
 	}
 }
@@ -53,20 +63,7 @@ type ZeroshotClassifyArgs struct {
 func (ZeroshotClassifyArgs) Kind() string { return "classify_zeroshot" }
 
 func (ZeroshotClassifyArgs) InsertOpts() river.InsertOpts {
-	return river.InsertOpts{
-		MaxAttempts: MLProcessMaxAttempts,
-		// Dedupe concurrent reindex/retry fan-out per asset: an equivalent job
-		// still available/running/completed in the table is silently skipped
-		// (Insert returns UniqueSkippedAsDuplicate=true, nil error). Default
-		// ByState includes completed, so overlapping full-rebuild chains collapse
-		// to one job per asset instead of racing the non-transactional OCR/face
-		// save paths. ByArgs also keys on PreprocessVersion, so bumping the
-		// version re-allows a re-run.
-		UniqueOpts: river.UniqueOpts{
-			ByArgs:   true,
-			ByPeriod: MLProcessUniquePeriod,
-		},
-	}
+	return mlProcessInsertOpts()
 }
 
 // ProcessBioClipArgs is the River job payload for BioCLIP classification.
@@ -79,20 +76,7 @@ type ProcessBioClipArgs struct {
 func (ProcessBioClipArgs) Kind() string { return "process_bioclip" }
 
 func (ProcessBioClipArgs) InsertOpts() river.InsertOpts {
-	return river.InsertOpts{
-		MaxAttempts: MLProcessMaxAttempts,
-		// Dedupe concurrent reindex/retry fan-out per asset: an equivalent job
-		// still available/running/completed in the table is silently skipped
-		// (Insert returns UniqueSkippedAsDuplicate=true, nil error). Default
-		// ByState includes completed, so overlapping full-rebuild chains collapse
-		// to one job per asset instead of racing the non-transactional OCR/face
-		// save paths. ByArgs also keys on PreprocessVersion, so bumping the
-		// version re-allows a re-run.
-		UniqueOpts: river.UniqueOpts{
-			ByArgs:   true,
-			ByPeriod: MLProcessUniquePeriod,
-		},
-	}
+	return mlProcessInsertOpts()
 }
 
 // AssetRetryPayload is the River job payload for selective retry of asset processing tasks
@@ -104,13 +88,22 @@ type AssetRetryPayload struct {
 
 func (AssetRetryPayload) Kind() string { return "retry_asset" }
 
-// InsertOpts implements JobArgsWithInsertOpts. Uniqueness is disabled to allow
-// multiple retry jobs per asset; processors must handle any dedupe logic.
+// InsertOpts collapses only overlapping retry requests for the same asset.
+// A completed retry never blocks a later explicit retry.
 func (AssetRetryPayload) InsertOpts() river.InsertOpts {
-	// Uniqueness biased by the time period, to avoid duplicate retry jobs in quick succession.
-	return river.InsertOpts{UniqueOpts: river.UniqueOpts{
-		ByPeriod: 1 * time.Minute,
-	}}
+	return river.InsertOpts{
+		UniqueOpts: river.UniqueOpts{
+			ByArgs:   true,
+			ByPeriod: 1 * time.Minute,
+			ByState: []rivertype.JobState{
+				rivertype.JobStateAvailable,
+				rivertype.JobStatePending,
+				rivertype.JobStateRetryable,
+				rivertype.JobStateRunning,
+				rivertype.JobStateScheduled,
+			},
+		},
+	}
 }
 
 // ProcessOcrArgs is the River job payload for OCR text extraction.
@@ -123,20 +116,7 @@ type ProcessOcrArgs struct {
 func (ProcessOcrArgs) Kind() string { return "process_ocr" }
 
 func (ProcessOcrArgs) InsertOpts() river.InsertOpts {
-	return river.InsertOpts{
-		MaxAttempts: MLProcessMaxAttempts,
-		// Dedupe concurrent reindex/retry fan-out per asset: an equivalent job
-		// still available/running/completed in the table is silently skipped
-		// (Insert returns UniqueSkippedAsDuplicate=true, nil error). Default
-		// ByState includes completed, so overlapping full-rebuild chains collapse
-		// to one job per asset instead of racing the non-transactional OCR/face
-		// save paths. ByArgs also keys on PreprocessVersion, so bumping the
-		// version re-allows a re-run.
-		UniqueOpts: river.UniqueOpts{
-			ByArgs:   true,
-			ByPeriod: MLProcessUniquePeriod,
-		},
-	}
+	return mlProcessInsertOpts()
 }
 
 // ProcessFaceArgs is the River job payload for face detection and recognition.
@@ -149,20 +129,7 @@ type ProcessFaceArgs struct {
 func (ProcessFaceArgs) Kind() string { return "process_face" }
 
 func (ProcessFaceArgs) InsertOpts() river.InsertOpts {
-	return river.InsertOpts{
-		MaxAttempts: MLProcessMaxAttempts,
-		// Dedupe concurrent reindex/retry fan-out per asset: an equivalent job
-		// still available/running/completed in the table is silently skipped
-		// (Insert returns UniqueSkippedAsDuplicate=true, nil error). Default
-		// ByState includes completed, so overlapping full-rebuild chains collapse
-		// to one job per asset instead of racing the non-transactional OCR/face
-		// save paths. ByArgs also keys on PreprocessVersion, so bumping the
-		// version re-allows a re-run.
-		UniqueOpts: river.UniqueOpts{
-			ByArgs:   true,
-			ByPeriod: MLProcessUniquePeriod,
-		},
-	}
+	return mlProcessInsertOpts()
 }
 
 // ProcessVideoFramesArgs is the River job payload for video frame semantic
@@ -176,13 +143,7 @@ type ProcessVideoFramesArgs struct {
 func (ProcessVideoFramesArgs) Kind() string { return "process_video_frames" }
 
 func (ProcessVideoFramesArgs) InsertOpts() river.InsertOpts {
-	return river.InsertOpts{
-		MaxAttempts: MLProcessMaxAttempts,
-		UniqueOpts: river.UniqueOpts{
-			ByArgs:   true,
-			ByPeriod: MLProcessUniquePeriod,
-		},
-	}
+	return mlProcessInsertOpts()
 }
 
 // ReindexAssetsArgs queues a batch backfill for existing photo indexing tasks.

--- a/server/internal/queue/jobs/types_test.go
+++ b/server/internal/queue/jobs/types_test.go
@@ -2,10 +2,12 @@ package jobs
 
 import (
 	"encoding/json"
+	"slices"
 	"testing"
 	"time"
 
 	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/rivertype"
 )
 
 func TestProcessArgsDecodeLegacyImageDataWithoutPersistingBytes(t *testing.T) {
@@ -48,6 +50,7 @@ func TestMLProcessArgsInsertOpts(t *testing.T) {
 		"ocr":      ProcessOcrArgs{}.InsertOpts(),
 		"face":     ProcessFaceArgs{}.InsertOpts(),
 		"zeroshot": ZeroshotClassifyArgs{}.InsertOpts(),
+		"video":    ProcessVideoFramesArgs{}.InsertOpts(),
 	}
 
 	for name, opts := range tests {
@@ -64,7 +67,36 @@ func TestMLProcessArgsInsertOpts(t *testing.T) {
 			if opts.UniqueOpts.ByPeriod != 5*time.Minute {
 				t.Fatalf("expected %s jobs to use a 5-minute uniqueness period, got %s", name, opts.UniqueOpts.ByPeriod)
 			}
+			if slices.Contains(opts.UniqueOpts.ByState, rivertype.JobStateCompleted) {
+				t.Fatalf("completed %s jobs must not block explicit reprocessing", name)
+			}
+			for _, state := range []rivertype.JobState{
+				rivertype.JobStateAvailable,
+				rivertype.JobStatePending,
+				rivertype.JobStateRetryable,
+				rivertype.JobStateRunning,
+				rivertype.JobStateScheduled,
+			} {
+				if !slices.Contains(opts.UniqueOpts.ByState, state) {
+					t.Fatalf("expected %s jobs to dedupe active state %s", name, state)
+				}
+			}
 		})
+	}
+}
+
+func TestAssetRetryPayloadDedupesOnlyOverlappingRequestsPerAsset(t *testing.T) {
+	t.Parallel()
+
+	opts := AssetRetryPayload{}.InsertOpts()
+	if !opts.UniqueOpts.ByArgs {
+		t.Fatal("retry jobs must be unique by asset arguments")
+	}
+	if slices.Contains(opts.UniqueOpts.ByState, rivertype.JobStateCompleted) {
+		t.Fatal("a completed retry must not block a later explicit retry")
+	}
+	if !slices.Contains(opts.UniqueOpts.ByState, rivertype.JobStateRunning) {
+		t.Fatal("overlapping running retries must be deduplicated")
 	}
 }
 

--- a/server/internal/utils/errgroup/fault_tolerant_test.go
+++ b/server/internal/utils/errgroup/fault_tolerant_test.go
@@ -3,6 +3,7 @@ package errgroup_test
 import (
 	"errors"
 	"fmt"
+	"sync/atomic"
 	"testing"
 
 	"server/internal/utils/errgroup"
@@ -14,21 +15,26 @@ func TestFaultTolerantGroup(t *testing.T) {
 	t.Run("All tasks succeed", func(t *testing.T) {
 		g := errgroup.NewFaultTolerant()
 
-		results := make([]int, 0)
+		completed := make(chan int, 3)
 		g.Go(func() error {
-			results = append(results, 1)
+			completed <- 1
 			return nil
 		})
 		g.Go(func() error {
-			results = append(results, 2)
+			completed <- 2
 			return nil
 		})
 		g.Go(func() error {
-			results = append(results, 3)
+			completed <- 3
 			return nil
 		})
 
 		errors := g.Wait()
+		close(completed)
+		results := make([]int, 0, 3)
+		for result := range completed {
+			results = append(results, result)
+		}
 		assert.Empty(t, errors, "Should have no errors when all tasks succeed")
 		assert.Len(t, results, 3, "All tasks should have executed")
 		assert.ElementsMatch(t, []int{1, 2, 3}, results, "All tasks should have completed")
@@ -37,27 +43,27 @@ func TestFaultTolerantGroup(t *testing.T) {
 	t.Run("Some tasks fail", func(t *testing.T) {
 		g := errgroup.NewFaultTolerant()
 
-		successCount := 0
+		var executionCount atomic.Int32
 		g.Go(func() error {
-			successCount++
+			executionCount.Add(1)
 			return nil
 		})
 		g.Go(func() error {
-			successCount++
+			executionCount.Add(1)
 			return errors.New("task 2 failed")
 		})
 		g.Go(func() error {
-			successCount++
+			executionCount.Add(1)
 			return nil
 		})
 		g.Go(func() error {
-			successCount++
+			executionCount.Add(1)
 			return errors.New("task 4 failed")
 		})
 
 		errors := g.Wait()
 		assert.Len(t, errors, 2, "Should have 2 errors")
-		assert.Equal(t, 4, successCount, "All tasks should have executed despite failures")
+		assert.EqualValues(t, 4, executionCount.Load(), "All tasks should have executed despite failures")
 
 		// Check error messages
 		errorMessages := make([]string, len(errors))
@@ -70,23 +76,23 @@ func TestFaultTolerantGroup(t *testing.T) {
 	t.Run("All tasks fail", func(t *testing.T) {
 		g := errgroup.NewFaultTolerant()
 
-		executionCount := 0
+		var executionCount atomic.Int32
 		g.Go(func() error {
-			executionCount++
+			executionCount.Add(1)
 			return errors.New("error 1")
 		})
 		g.Go(func() error {
-			executionCount++
+			executionCount.Add(1)
 			return errors.New("error 2")
 		})
 		g.Go(func() error {
-			executionCount++
+			executionCount.Add(1)
 			return errors.New("error 3")
 		})
 
 		errors := g.Wait()
 		assert.Len(t, errors, 3, "Should have 3 errors")
-		assert.Equal(t, 3, executionCount, "All tasks should have executed")
+		assert.EqualValues(t, 3, executionCount.Load(), "All tasks should have executed")
 	})
 
 	t.Run("No tasks", func(t *testing.T) {

--- a/server/tools/fakelumen/main.go
+++ b/server/tools/fakelumen/main.go
@@ -15,8 +15,10 @@ import (
 	"io"
 	"log"
 	"net"
+	"net/http"
 	"os"
 	"os/signal"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -30,13 +32,20 @@ import (
 )
 
 const (
-	defaultAddress = ":50051"
-	modelID        = "lumilio-e2e-deterministic-v1"
+	defaultAddress        = ":50051"
+	defaultMetricsAddress = ":50052"
+	modelID               = "lumilio-e2e-deterministic-v1"
 )
+
+type inferenceMetrics struct {
+	semanticImage atomic.Uint64
+	semanticText  atomic.Uint64
+}
 
 type inferenceServer struct {
 	pb.UnimplementedInferenceServer
-	result []byte
+	result  []byte
+	metrics *inferenceMetrics
 }
 
 func newInferenceServer() (*inferenceServer, error) {
@@ -50,7 +59,7 @@ func newInferenceServer() (*inferenceServer, error) {
 	if err != nil {
 		return nil, fmt.Errorf("marshal deterministic embedding: %w", err)
 	}
-	return &inferenceServer{result: result}, nil
+	return &inferenceServer{result: result, metrics: &inferenceMetrics{}}, nil
 }
 
 func semanticCapability() *pb.Capability {
@@ -115,7 +124,10 @@ func (s *inferenceServer) Infer(stream grpc.BidiStreamingServer[pb.InferRequest,
 		return status.Error(codes.InvalidArgument, "inference request is empty")
 	}
 	switch request.GetTask() {
-	case types.TaskSemanticImageEmbed, types.TaskSemanticTextEmbed:
+	case types.TaskSemanticImageEmbed:
+		s.metrics.semanticImage.Add(1)
+	case types.TaskSemanticTextEmbed:
+		s.metrics.semanticText.Add(1)
 	default:
 		return status.Errorf(codes.Unimplemented, "unsupported E2E task %q", request.GetTask())
 	}
@@ -148,12 +160,29 @@ func runHealthCheck(endpoint string) error {
 	return err
 }
 
-func run(address string) error {
+func metricsHandler(metrics *inferenceMetrics) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /metrics", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]uint64{
+			"semantic_image": metrics.semanticImage.Load(),
+			"semantic_text":  metrics.semanticText.Load(),
+		})
+	})
+	return mux
+}
+
+func run(address string, metricsAddress string) error {
 	listener, err := net.Listen("tcp", address)
 	if err != nil {
 		return err
 	}
 	defer listener.Close()
+	metricsListener, err := net.Listen("tcp", metricsAddress)
+	if err != nil {
+		return err
+	}
+	defer metricsListener.Close()
 
 	service, err := newInferenceServer()
 	if err != nil {
@@ -161,16 +190,38 @@ func run(address string) error {
 	}
 	server := grpc.NewServer()
 	pb.RegisterInferenceServer(server, service)
+	metricsServer := &http.Server{
+		Handler:           metricsHandler(service.metrics),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
+	serveErrors := make(chan error, 2)
 	go func() {
-		<-ctx.Done()
-		server.GracefulStop()
+		serveErrors <- server.Serve(listener)
+	}()
+	go func() {
+		serveErrors <- metricsServer.Serve(metricsListener)
 	}()
 
-	log.Printf("deterministic Lumen E2E fixture listening on %s", listener.Addr())
-	if err := server.Serve(listener); err != nil && !errors.Is(err, grpc.ErrServerStopped) {
+	log.Printf(
+		"deterministic Lumen E2E fixture listening on %s (metrics %s)",
+		listener.Addr(),
+		metricsListener.Addr(),
+	)
+	select {
+	case <-ctx.Done():
+	case err := <-serveErrors:
+		if err != nil && !errors.Is(err, grpc.ErrServerStopped) && !errors.Is(err, http.ErrServerClosed) {
+			return err
+		}
+	}
+
+	server.GracefulStop()
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := metricsServer.Shutdown(shutdownCtx); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		return err
 	}
 	return nil
@@ -178,6 +229,7 @@ func run(address string) error {
 
 func main() {
 	address := flag.String("listen", defaultAddress, "gRPC listen address")
+	metricsAddress := flag.String("metrics-listen", defaultMetricsAddress, "HTTP metrics listen address")
 	healthCheck := flag.String("health-check", "", "probe an existing fixture endpoint")
 	flag.Parse()
 
@@ -185,7 +237,7 @@ func main() {
 	if *healthCheck != "" {
 		err = runHealthCheck(*healthCheck)
 	} else {
-		err = run(*address)
+		err = run(*address, *metricsAddress)
 	}
 	if err != nil {
 		log.Fatal(err)

--- a/server/tools/fakelumen/main_test.go
+++ b/server/tools/fakelumen/main_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestMetricsHandlerReportsInferenceCounts(t *testing.T) {
+	t.Parallel()
+
+	metrics := &inferenceMetrics{}
+	metrics.semanticImage.Add(3)
+	metrics.semanticText.Add(2)
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	metricsHandler(metrics).ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d", recorder.Code)
+	}
+	var body map[string]uint64
+	if err := json.Unmarshal(recorder.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body["semantic_image"] != 3 || body["semantic_text"] != 2 {
+		t.Fatalf("unexpected metrics: %#v", body)
+	}
+}

--- a/web/e2e/specs/video-semantic-regression.spec.ts
+++ b/web/e2e/specs/video-semantic-regression.spec.ts
@@ -1,0 +1,511 @@
+import { readFileSync } from "node:fs";
+import process from "node:process";
+import { expect, test } from "../fixtures/test";
+import { LoginPage } from "../pages/login.page";
+import { api, baseURL } from "../support/api";
+import {
+  profileAsset,
+  VIDEO_REGRESSION_ASSETS,
+  VIDEO_REGRESSION_PHOTO_ASSET,
+  VIDEO_REGRESSION_PROFILE,
+} from "../support/assets";
+
+type Asset = {
+  asset_id: string;
+  original_filename: string;
+  type: "PHOTO" | "VIDEO";
+};
+
+type BrowseItem = {
+  asset?: Asset;
+  best_ts_ms?: number;
+};
+
+type QueryResponse = {
+  items?: BrowseItem[];
+};
+
+type SearchResponse = {
+  top_items?: BrowseItem[];
+  result_items?: BrowseItem[];
+};
+
+type Repository = {
+  id: string;
+  name: string;
+};
+
+type IndexingTaskStats = {
+  indexed_count: number;
+  queued_jobs: number;
+  total_count: number;
+};
+
+type IndexingStats = {
+  photo_total: number;
+  video_total: number;
+  reindex_jobs: number;
+  tasks: {
+    semantic: IndexingTaskStats;
+    video_semantic: IndexingTaskStats;
+  };
+};
+
+type LumenMetrics = {
+  semantic_image: number;
+  semantic_text: number;
+};
+
+type QueueSummary = {
+  queues: {
+    name: string;
+    remaining_jobs: number;
+  }[];
+};
+
+type MLSettings = {
+  semantic_enabled: boolean;
+  bioclip_enabled: boolean;
+  ocr_enabled: boolean;
+  face_enabled: boolean;
+  video_semantic_enabled: boolean;
+  video_max_frames: number;
+  video_long_threshold_seconds: number;
+  video_scene_threshold: number;
+};
+
+type SystemSettings = {
+  ml: MLSettings;
+};
+
+const lumenMetricsURL =
+  process.env.LUMILIO_E2E_LUMEN_METRICS_URL ?? "http://127.0.0.1:16658/metrics";
+const frameCap = 2;
+
+async function getLumenMetrics(): Promise<LumenMetrics> {
+  const response = await fetch(lumenMetricsURL);
+  if (!response.ok) throw new Error(`GET ${lumenMetricsURL}: ${response.status}`);
+  return response.json() as Promise<LumenMetrics>;
+}
+
+async function ensureRepository(token: string, name: string): Promise<Repository> {
+  const { repositories } = await api<{ repositories: Repository[] }>("/api/v1/repositories", {
+    token,
+  });
+  const existing = repositories.find((repository) => repository.name === name);
+  if (existing) return existing;
+
+  const { repository } = await api<{ repository: Repository }>("/api/v1/repositories", {
+    method: "POST",
+    token,
+    body: JSON.stringify({
+      name,
+      role: "regular",
+      storage_strategy: "flat",
+      duplicate_handling: "rename",
+    }),
+  });
+  return repository;
+}
+
+async function uploadAsset(
+  token: string,
+  repositoryID: string,
+  source: string,
+  filename: string,
+  mimeType: string,
+) {
+  const form = new FormData();
+  form.append("repository_id", repositoryID);
+  form.append(
+    "file",
+    new Blob([new Uint8Array(readFileSync(source))], { type: mimeType }),
+    filename,
+  );
+  const response = await fetch(`${baseURL}/api/v1/assets`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${token}` },
+    body: form,
+  });
+  const body: unknown = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    throw new Error(`POST /api/v1/assets: ${response.status} ${JSON.stringify(body)}`);
+  }
+}
+
+async function findAsset(
+  token: string,
+  repositoryID: string,
+  filename: string,
+): Promise<Asset | undefined> {
+  const response = await api<QueryResponse>("/api/v1/assets/list", {
+    method: "POST",
+    token,
+    body: JSON.stringify({
+      query: filename,
+      search_type: "filename",
+      filter: { repository_id: repositoryID },
+      pagination: { limit: 50, offset: 0 },
+      stack_mode: "expanded",
+    }),
+  });
+  return response.items
+    ?.map((item) => item.asset)
+    .find((asset): asset is Asset => asset?.original_filename === filename);
+}
+
+async function waitForAsset(token: string, repositoryID: string, filename: string): Promise<Asset> {
+  let matched: Asset | undefined;
+  await expect
+    .poll(
+      async () => {
+        matched = await findAsset(token, repositoryID, filename);
+        return matched?.asset_id;
+      },
+      {
+        message: `${filename} should finish ingest and appear in browse`,
+        timeout: 120_000,
+        intervals: [500, 1_000, 2_000],
+      },
+    )
+    .toBeTruthy();
+  return matched as Asset;
+}
+
+function getIndexingStats(token: string, repositoryID: string) {
+  return api<IndexingStats>(
+    `/api/v1/assets/indexing/stats?repository_id=${encodeURIComponent(repositoryID)}`,
+    { token },
+  );
+}
+
+async function waitForIndexingCoverage(
+  token: string,
+  repositoryID: string,
+  expectedPhotos: number,
+  expectedVideos: number,
+) {
+  await expect
+    .poll(
+      async () => {
+        const stats = await getIndexingStats(token, repositoryID);
+        return {
+          photoIndexed: stats.tasks.semantic.indexed_count,
+          photoTotal: stats.photo_total,
+          videoIndexed: stats.tasks.video_semantic.indexed_count,
+          videoTotal: stats.video_total,
+        };
+      },
+      {
+        message: "semantic indexing coverage should reach the repository totals",
+        timeout: 180_000,
+        intervals: [500, 1_000, 2_000],
+      },
+    )
+    .toEqual({
+      photoIndexed: expectedPhotos,
+      photoTotal: expectedPhotos,
+      videoIndexed: expectedVideos,
+      videoTotal: expectedVideos,
+    });
+}
+
+async function waitForDisabledVideoCoverage(token: string, repositoryID: string) {
+  await expect
+    .poll(
+      async () => {
+        const stats = await getIndexingStats(token, repositoryID);
+        return {
+          indexed: stats.tasks.video_semantic.indexed_count,
+          total: stats.video_total,
+        };
+      },
+      {
+        message: "the AI-disabled video should stay intentionally unindexed",
+        timeout: 120_000,
+        intervals: [500, 1_000, 2_000],
+      },
+    )
+    .toEqual({ indexed: 0, total: 1 });
+}
+
+async function waitForQueuesIdle(token: string, names: string[]) {
+  await expect
+    .poll(
+      async () => {
+        const summary = await api<QueueSummary>("/api/v1/admin/river/queue-summary", {
+          token,
+        });
+        return Object.fromEntries(
+          names.map((name) => [
+            name,
+            summary.queues.find((queue) => queue.name === name)?.remaining_jobs ?? 0,
+          ]),
+        );
+      },
+      {
+        message: `${names.join(", ")} should become idle`,
+        timeout: 180_000,
+        intervals: [500, 1_000, 2_000],
+      },
+    )
+    .toEqual(Object.fromEntries(names.map((name) => [name, 0])));
+}
+
+async function waitForImageInferencesAtLeast(previous: number, expectedDelta: number) {
+  await expect
+    .poll(async () => (await getLumenMetrics()).semantic_image - previous, {
+      message: `the Lumen fixture should receive at least ${expectedDelta} new image inferences`,
+      timeout: 180_000,
+      intervals: [500, 1_000, 2_000],
+    })
+    .toBeGreaterThanOrEqual(expectedDelta);
+}
+
+async function waitForWebVideo(token: string, assetID: string) {
+  await expect
+    .poll(
+      async () => {
+        const response = await fetch(`${baseURL}/api/v1/assets/${assetID}/video/web`, {
+          method: "HEAD",
+          headers: { authorization: `Bearer ${token}` },
+        });
+        return response.status;
+      },
+      {
+        message: "the AI-disabled video should still produce a playable web rendition",
+        timeout: 120_000,
+        intervals: [500, 1_000, 2_000],
+      },
+    )
+    .toBe(200);
+}
+
+test("@video-regression pinned videos cover semantic indexing lifecycle", async ({
+  page,
+  workspace,
+}, testInfo) => {
+  test.setTimeout(600_000);
+
+  const originalSettings = await api<SystemSettings>("/api/v1/settings/system", {
+    token: workspace.token,
+  });
+  const runLabel = `Run ${testInfo.retry}`;
+  const repository = await ensureRepository(
+    workspace.token,
+    `Video Semantic Regression ${runLabel}`,
+  );
+  const disabledRepository = await ensureRepository(
+    workspace.token,
+    `Video Semantic Disabled Regression ${runLabel}`,
+  );
+
+  try {
+    await api<SystemSettings>("/api/v1/settings/system", {
+      method: "PATCH",
+      token: workspace.token,
+      body: JSON.stringify({
+        ml: {
+          semantic_enabled: true,
+          video_semantic_enabled: true,
+          video_max_frames: frameCap,
+        },
+      }),
+    });
+    await waitForQueuesIdle(workspace.token, [
+      "process_semantic",
+      "process_video_frames",
+      "reindex_assets",
+      "retry_asset",
+    ]);
+
+    const photoFilename = "video-regression-photo.jpg";
+    const photoStartedAt = Date.now();
+    const beforePhoto = await getLumenMetrics();
+    await uploadAsset(
+      workspace.token,
+      repository.id,
+      profileAsset(VIDEO_REGRESSION_PROFILE, VIDEO_REGRESSION_PHOTO_ASSET),
+      photoFilename,
+      "image/jpeg",
+    );
+    await waitForAsset(workspace.token, repository.id, photoFilename);
+    await waitForIndexingCoverage(workspace.token, repository.id, 1, 0);
+    await waitForQueuesIdle(workspace.token, ["process_semantic"]);
+    await waitForImageInferencesAtLeast(beforePhoto.semantic_image, 1);
+    const photoIndexedMs = Date.now() - photoStartedAt;
+
+    const timings: { filename: string; indexed_ms: number; frames: number }[] = [];
+    const videos: Asset[] = [];
+    for (const [index, fixtureID] of VIDEO_REGRESSION_ASSETS.entries()) {
+      const filename = `video-regression-${index + 1}.mp4`;
+      const startedAt = Date.now();
+      const before = await getLumenMetrics();
+      await uploadAsset(
+        workspace.token,
+        repository.id,
+        profileAsset(VIDEO_REGRESSION_PROFILE, fixtureID),
+        filename,
+        "video/mp4",
+      );
+      const asset = await waitForAsset(workspace.token, repository.id, filename);
+      videos.push(asset);
+      await waitForIndexingCoverage(workspace.token, repository.id, 1, index + 1);
+      await waitForQueuesIdle(workspace.token, ["process_video_frames"]);
+
+      const after = await getLumenMetrics();
+      const frames = after.semantic_image - before.semantic_image;
+      expect(frames, `${filename} should produce at least one semantic frame`).toBeGreaterThan(0);
+      expect(frames, `${filename} should respect video_max_frames`).toBeLessThanOrEqual(frameCap);
+      timings.push({ filename, indexed_ms: Date.now() - startedAt, frames });
+    }
+
+    await test.step("photo and videos coexist in semantic text search", async () => {
+      const response = await api<SearchResponse>("/api/v1/assets/search", {
+        method: "POST",
+        token: workspace.token,
+        body: JSON.stringify({
+          query: "deterministic mixed media",
+          filter: { repository_id: repository.id },
+          pagination: { limit: 50, offset: 0 },
+          enhancement_mode: "auto",
+          top_results_limit: 50,
+          stack_mode: "expanded",
+        }),
+      });
+      const assets = [...(response.top_items ?? []), ...(response.result_items ?? [])]
+        .map((item) => item.asset)
+        .filter((asset): asset is Asset => Boolean(asset));
+      expect(
+        assets.some((asset) => asset.original_filename === photoFilename && asset.type === "PHOTO"),
+      ).toBe(true);
+      expect(
+        assets.some(
+          (asset) =>
+            asset.original_filename.startsWith("video-regression-") && asset.type === "VIDEO",
+        ),
+      ).toBe(true);
+    });
+
+    const initialFrameTotal = timings.reduce((sum, timing) => sum + timing.frames, 0);
+
+    await test.step("video semantic backfill re-embeds all pinned videos", async () => {
+      const before = await getLumenMetrics();
+      const response = await api<{ status: string; requested_tasks: string[] }>(
+        "/api/v1/assets/indexing/rebuild",
+        {
+          method: "POST",
+          token: workspace.token,
+          body: JSON.stringify({
+            repository_id: repository.id,
+            tasks: ["video_semantic"],
+            limit: 50,
+            missing_only: false,
+          }),
+        },
+      );
+      expect(response.status).toBe("queued");
+      expect(response.requested_tasks).toContain("video_semantic");
+      await waitForImageInferencesAtLeast(before.semantic_image, initialFrameTotal);
+      await waitForQueuesIdle(workspace.token, ["reindex_assets", "process_video_frames"]);
+      await waitForIndexingCoverage(workspace.token, repository.id, 1, videos.length);
+    });
+
+    await test.step("semantic reset refills photo and video indexes", async () => {
+      const before = await getLumenMetrics();
+      const response = await api<{ status: string; requested_tasks: string[] }>(
+        "/api/v1/assets/indexing/rebuild",
+        {
+          method: "POST",
+          token: workspace.token,
+          body: JSON.stringify({
+            tasks: ["semantic"],
+            limit: 50,
+            missing_only: false,
+            reset_semantic: true,
+          }),
+        },
+      );
+      expect(response.status).toBe("queued");
+      expect(response.requested_tasks).toContain("semantic");
+      await waitForImageInferencesAtLeast(before.semantic_image, initialFrameTotal + 1);
+      await waitForQueuesIdle(workspace.token, [
+        "reindex_assets",
+        "process_semantic",
+        "process_video_frames",
+      ]);
+      await waitForIndexingCoverage(workspace.token, repository.id, 1, videos.length);
+    });
+
+    await test.step("selective retry re-runs video frame indexing", async () => {
+      const before = await getLumenMetrics();
+      const response = await api<{ status: string; retry_tasks: string[] }>(
+        `/api/v1/assets/${videos[0].asset_id}/reprocess`,
+        {
+          method: "POST",
+          token: workspace.token,
+          body: JSON.stringify({ tasks: ["process_video_frames"] }),
+        },
+      );
+      expect(response.status).toBe("queued");
+      expect(response.retry_tasks).toEqual(["process_video_frames"]);
+      await waitForImageInferencesAtLeast(before.semantic_image, timings[0].frames);
+      await waitForQueuesIdle(workspace.token, ["retry_asset", "process_video_frames"]);
+    });
+
+    await test.step("disabled ML preserves video ingest, browse, and playback", async () => {
+      await api<SystemSettings>("/api/v1/settings/system", {
+        method: "PATCH",
+        token: workspace.token,
+        body: JSON.stringify({
+          ml: {
+            semantic_enabled: false,
+            bioclip_enabled: false,
+            ocr_enabled: false,
+            face_enabled: false,
+            video_semantic_enabled: false,
+          },
+        }),
+      });
+
+      const before = await getLumenMetrics();
+      const filename = "video-regression-ai-disabled.mp4";
+      await uploadAsset(
+        workspace.token,
+        disabledRepository.id,
+        profileAsset(VIDEO_REGRESSION_PROFILE, VIDEO_REGRESSION_ASSETS[0]),
+        filename,
+        "video/mp4",
+      );
+      const asset = await waitForAsset(workspace.token, disabledRepository.id, filename);
+      expect(asset.type).toBe("VIDEO");
+      await waitForWebVideo(workspace.token, asset.asset_id);
+      await waitForDisabledVideoCoverage(workspace.token, disabledRepository.id);
+      expect((await getLumenMetrics()).semantic_image).toBe(before.semantic_image);
+
+      await new LoginPage(page).signIn(workspace.username, workspace.password);
+      await page.goto(`/assets/${asset.asset_id}`);
+      const video = page.getByRole("region", { name: new RegExp(filename, "i") }).locator("video");
+      await expect(video).toBeVisible({ timeout: 30_000 });
+      await expect
+        .poll(() => video.evaluate((element) => (element as HTMLVideoElement).readyState))
+        .toBeGreaterThanOrEqual(1);
+    });
+
+    console.log(
+      `LUMILIO_VIDEO_SEMANTIC_BASELINE ${JSON.stringify({
+        kind: "cpu_ffmpeg_pipeline_with_deterministic_lumen",
+        platform: process.platform,
+        arch: process.arch,
+        photo_indexed_ms: photoIndexedMs,
+        videos: timings,
+      })}`,
+    );
+  } finally {
+    await api<SystemSettings>("/api/v1/settings/system", {
+      method: "PATCH",
+      token: workspace.token,
+      body: JSON.stringify({ ml: originalSettings.ml }),
+    });
+  }
+});

--- a/web/e2e/support/assets.ts
+++ b/web/e2e/support/assets.ts
@@ -7,33 +7,44 @@ const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url))
 const lock: { revision: string; profile: string } = JSON.parse(
   readFileSync(path.join(repositoryRoot, "assets.lock.json"), "utf8"),
 );
-const profileRoot = path.join(
-  repositoryRoot,
-  ".cache/lumilio-assets",
-  lock.revision,
-  lock.profile,
-);
 
 // `assets.json` catalogues the whole asset repository, but `assets:sync` only
 // materialises the ids the profile references. Resolving through the profile
 // keeps this to files that are actually on disk.
-const profile: { assets: string[] } = JSON.parse(
-  readFileSync(path.join(profileRoot, "profiles", `${lock.profile}.json`), "utf8"),
-);
-const catalog: { assets: { id: string; path: string }[] } = JSON.parse(
-  readFileSync(path.join(profileRoot, "assets.json"), "utf8"),
-);
+export function profileAsset(profileName: string, id: string): string {
+  const profileRoot = path.join(
+    repositoryRoot,
+    ".cache/lumilio-assets",
+    lock.revision,
+    profileName,
+  );
+  const profile: { assets: string[] } = JSON.parse(
+    readFileSync(path.join(profileRoot, "profiles", `${profileName}.json`), "utf8"),
+  );
+  const catalog: { assets: { id: string; path: string }[] } = JSON.parse(
+    readFileSync(path.join(profileRoot, "assets.json"), "utf8"),
+  );
 
-/** Absolute path of one profile asset, addressed by its stable id. */
-export function smokeAsset(id: string): string {
   if (!profile.assets.includes(id)) {
-    throw new Error(`asset ${id} is not in the ${lock.profile} profile`);
+    throw new Error(`asset ${id} is not in the ${profileName} profile`);
   }
   const asset = catalog.assets.find((candidate) => candidate.id === id);
   if (!asset) throw new Error(`asset ${id} is missing from the catalogue`);
   return path.join(profileRoot, asset.path);
 }
 
+/** Absolute path of one smoke-profile asset, addressed by its stable id. */
+export function smokeAsset(id: string): string {
+  return profileAsset(lock.profile, id);
+}
+
 export const SMOKE_SCAN_ASSET = "picsum-scan-000";
 export const SMOKE_UPLOAD_ASSET = "picsum-upload-123";
 export const SMOKE_VIDEO_ASSET = "commons-video-ocean-waves";
+export const VIDEO_REGRESSION_PROFILE = "e2e";
+export const VIDEO_REGRESSION_PHOTO_ASSET = "picsum-upload-124";
+export const VIDEO_REGRESSION_ASSETS = [
+  "commons-video-ocean-waves",
+  "commons-video-chameleon-flowers",
+  "commons-video-mountain-landscape",
+] as const;

--- a/web/package.json
+++ b/web/package.json
@@ -10,6 +10,7 @@
     "e2e:down": "node e2e/support/environment.mjs down",
     "e2e:logs": "node e2e/support/environment.mjs logs",
     "e2e:seed": "vp run assets:sync && node e2e/support/seed.mjs",
+    "e2e:seed:video-semantic": "vp run assets:sync -- --profile e2e && node e2e/support/seed.mjs",
     "e2e:test": "playwright test",
     "demo:seed": "node scripts/demo-seed.mjs",
     "setup:depth": "node scripts/fetch-depth-model.mjs",
@@ -28,6 +29,7 @@
     "test:hash-perf": "VITEST_HASH_PERF=true vp test run src/workers/hash.perf.test.ts",
     "test:watch": "vp test watch",
     "test:browser": "vp run e2e:test --grep @smoke",
+    "test:video-semantic": "vp run e2e:test --grep @video-regression --workers=1",
     "test:bundle": "vp build && node scripts/check-bundle-budget.mjs",
     "test:ui": "vp test --ui"
   },


### PR DESCRIPTION
## What changed

- add a real-asset Playwright regression matrix for one photo and three videos, covering semantic indexing, mixed photo/video search, frame caps, scoped backfill, global reset/refill, selective video retry, and AI-disabled browsing/playback
- expose deterministic fake-Lumen inference counters to make indexing assertions observable and reproducible
- run the new matrix in Web CI and add focused local test targets
- allow `process_video_frames` through the public reprocess validation path
- keep ML job uniqueness for active work while permitting explicit reprocessing after a completed job
- remove shared-memory data races from the existing fault-tolerant errgroup tests exposed by Windows CI

## Why

The previous smoke coverage proved one short video path but did not protect the full video-semantic lifecycle or multiple durations. During the new backfill scenario, completed River jobs were still inside the five-minute uniqueness window, so explicit backfill/reset/retry requests found candidates but silently queued no work. The updated uniqueness state filter excludes completed jobs while continuing to deduplicate overlapping active jobs.

The first independent CI run also exposed an old test defect: concurrent tasks appended to the same slice and incremented plain integers without synchronization. Windows lost writes and failed the assertion. The test now collects results through a channel and counts execution atomically; product errgroup behavior is unchanged.

## Impact

Video semantic behavior now has repeatable end-to-end protection with pinned Git LFS assets. Explicit backfill, reset, and retry operations can actually reprocess recently completed assets. Required CI no longer depends on racy test bookkeeping. No Lumen Hub or Lumen SDK changes are included.

## Validation

- `make server-test`
- `make web-test`
- `make desktop-test`
- clean `make dev-reset`
- `make web-video-semantic-test`: 1 passed
- `make web-browser-test`: 7 passed
- `go test -race -count=100 ./internal/utils/errgroup`
- targeted Go and static checks

Local ARM64 baseline with CPU FFmpeg and deterministic fake Lumen, frame cap 2:

- photo: 0.56 s
- 3.5 s video: 4.13 s / 1 frame
- 6.6 s video: 8.13 s / 2 frames
- 14.6 s video: 4.10 s / 2 frames