### PR TITLE
Activate GitHub agent task intake on main

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security report / 安全问题
+    url: https://github.com/edwinzhancn/Lumilio-Photos/security/advisories/new
+    about: Report vulnerabilities privately; never put secrets in a public Issue. / 请私下报告漏洞，切勿在公开 Issue 中提交密钥。

--- a/.github/ISSUE_TEMPLATE/quick-task.yml
+++ b/.github/ISSUE_TEMPLATE/quick-task.yml
@@ -1,0 +1,64 @@
+name: Quick task / 快速记录
+description: Capture a bug or improvement for maintainer triage in under 30 seconds / 快速记录错误或改进
+title: "[Quick] "
+labels:
+  - quick-capture
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Save the observation first; incomplete reproduction steps are fine.
+
+        请先记录观察结果；复现步骤不完整也没关系。
+
+        **Privacy / 隐私：** Do not attach original media, database files, secret values, local paths, or unsanitized logs. 请勿附加原始媒体、数据库、密钥、本地路径或未经清理的日志。
+
+  - type: textarea
+    id: observation
+    attributes:
+      label: What happened or should change? / 发生了什么或希望如何修改？
+      description: Describe the visible problem or desired outcome in a few sentences. / 用几句话描述可见问题或期望结果。
+      placeholder: The thumbnail action stopped responding after… / 缩略图操作在……之后没有响应
+    validations:
+      required: true
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Surface / 范围
+      options:
+        - Unknown / 不确定
+        - Web
+        - Server
+        - Desktop
+        - Deploy
+        - Docs
+        - Cross-cutting / 跨模块
+    validations:
+      required: false
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction notes / 复现线索
+      description: Optional rough steps, frequency, and expected behavior. / 可选：粗略步骤、频率和预期行为。
+      placeholder: Open an album, select an asset, then… / 打开相册、选择资源，然后……
+    validations:
+      required: false
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Sanitized evidence / 已清理的证据
+      description: Optional screenshots or short excerpts with secrets, media, paths, and personal data removed. / 可选：已移除密钥、媒体、路径和个人信息的截图或短摘录。
+    validations:
+      required: false
+
+  - type: input
+    id: environment
+    attributes:
+      label: Version and environment / 版本与环境
+      description: Optional sanitized version, platform, browser, and route. / 可选：已清理的版本、平台、浏览器和页面路径。
+      placeholder: dev@abc123, macOS, Chromium, /assets / 开发版、macOS、Chromium、/assets
+    validations:
+      required: false

--- a/.github/workflows/agent-command.yml
+++ b/.github/workflows/agent-command.yml
@@ -1,0 +1,154 @@
+name: Agent command
+
+on:
+    issue_comment:
+        types: [created]
+    workflow_dispatch:
+        inputs:
+            issue_number:
+                description: Managed Issue number
+                required: true
+                type: string
+            command:
+                description: Codex Cloud handoff command
+                required: true
+                type: choice
+                options:
+                    - retry
+                    - revise
+
+permissions:
+    contents: read
+    issues: write
+
+concurrency:
+    group: agent-task-${{ github.event.issue.number || inputs.issue_number }}
+    cancel-in-progress: false
+
+jobs:
+    authorize:
+        name: Authorize comment command
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        outputs:
+            authorized: ${{ steps.policy.outputs.authorized }}
+            reason: ${{ steps.policy.outputs.reason }}
+            issue_number: ${{ steps.policy.outputs.issue_number }}
+            content_id: ${{ steps.policy.outputs.content_id }}
+            mode: ${{ steps.policy.outputs.mode }}
+            comment_id: ${{ steps.policy.outputs.comment_id }}
+            resume: ${{ steps.policy.outputs.resume }}
+        steps:
+            - uses: actions/checkout@v7
+              with:
+                  persist-credentials: false
+                  ref: ${{ vars.AGENT_BASE_BRANCH || 'dev' }}
+
+            - uses: actions/setup-node@v6
+              with:
+                  node-version: '24'
+
+            - name: Parse command and check actor permission
+              id: policy
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}
+                  ISSUE_NUMBER: ${{ inputs.issue_number }}
+                  AGENT_COMMAND: ${{ inputs.command }}
+              run: node .github/codex/scripts/agent-loop.mjs authorize-command
+
+    handoff:
+        name: Prepare a revised Codex Cloud handoff
+        needs: authorize
+        if: needs.authorize.outputs.authorized == 'true' && needs.authorize.outputs.mode != 'submit' && needs.authorize.outputs.resume == ''
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+        permissions:
+            contents: read
+            issues: write
+        steps:
+            - uses: actions/checkout@v7
+              with:
+                  persist-credentials: false
+                  ref: ${{ vars.AGENT_BASE_BRANCH || 'dev' }}
+
+            - uses: actions/setup-node@v6
+              with:
+                  node-version: '24'
+
+            - name: Publish the next subscription-backed Cloud handoff
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}
+                  AGENT_PROJECT_TOKEN: ${{ secrets.AGENT_PROJECT_TOKEN }}
+                  AGENT_PROJECT_OWNER: ${{ vars.AGENT_PROJECT_OWNER }}
+                  AGENT_PROJECT_NUMBER: ${{ vars.AGENT_PROJECT_NUMBER }}
+                  AGENT_BASE_BRANCH: ${{ vars.AGENT_BASE_BRANCH || 'dev' }}
+                  AGENT_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                  ISSUE_NUMBER: ${{ needs.authorize.outputs.issue_number }}
+                  CONTENT_ID: ${{ needs.authorize.outputs.content_id }}
+                  HANDOFF_MODE: ${{ needs.authorize.outputs.mode }}
+                  FEEDBACK_COMMENT_ID: ${{ needs.authorize.outputs.comment_id }}
+                  TRIAGE_PROMPT_TEMPLATE: .github/codex/prompts/triage.md
+              run: node .github/codex/scripts/agent-loop.mjs prepare-cloud-handoff
+
+    submit:
+        name: Validate the returned Codex Cloud preflight
+        needs: authorize
+        if: needs.authorize.outputs.authorized == 'true' && needs.authorize.outputs.mode == 'submit'
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+        permissions:
+            contents: read
+            issues: write
+        steps:
+            - uses: actions/checkout@v7
+              with:
+                  persist-credentials: false
+                  ref: ${{ vars.AGENT_BASE_BRANCH || 'dev' }}
+
+            - uses: actions/setup-node@v6
+              with:
+                  node-version: '24'
+
+            - name: Validate JSON and publish the managed contract
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}
+                  AGENT_PROJECT_TOKEN: ${{ secrets.AGENT_PROJECT_TOKEN }}
+                  AGENT_PROJECT_OWNER: ${{ vars.AGENT_PROJECT_OWNER }}
+                  AGENT_PROJECT_NUMBER: ${{ vars.AGENT_PROJECT_NUMBER }}
+                  AGENT_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                  ISSUE_NUMBER: ${{ needs.authorize.outputs.issue_number }}
+                  CONTENT_ID: ${{ needs.authorize.outputs.content_id }}
+                  FEEDBACK_COMMENT_ID: ${{ needs.authorize.outputs.comment_id }}
+                  TRIAGE_MODE: submit
+              run: node .github/codex/scripts/agent-loop.mjs publish-comment-triage
+
+    resume:
+        name: Retry the existing published transition
+        needs: authorize
+        if: needs.authorize.outputs.authorized == 'true' && needs.authorize.outputs.resume != ''
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        permissions:
+            contents: read
+            issues: write
+        steps:
+            - uses: actions/checkout@v7
+              with:
+                  persist-credentials: false
+                  ref: ${{ vars.AGENT_BASE_BRANCH || 'dev' }}
+
+            - uses: actions/setup-node@v6
+              with:
+                  node-version: '24'
+
+            - name: Restore the approved triage state without a model call
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}
+                  AGENT_PROJECT_TOKEN: ${{ secrets.AGENT_PROJECT_TOKEN }}
+                  AGENT_PROJECT_OWNER: ${{ vars.AGENT_PROJECT_OWNER }}
+                  AGENT_PROJECT_NUMBER: ${{ vars.AGENT_PROJECT_NUMBER }}
+                  AGENT_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                  ISSUE_NUMBER: ${{ needs.authorize.outputs.issue_number }}
+                  CONTENT_ID: ${{ needs.authorize.outputs.content_id }}
+                  RESUME_KIND: ${{ needs.authorize.outputs.resume }}
+              run: node .github/codex/scripts/agent-loop.mjs resume

--- a/.github/workflows/agent-intake.yml
+++ b/.github/workflows/agent-intake.yml
@@ -1,0 +1,91 @@
+name: Agent intake
+
+on:
+    issues:
+        types: [opened, reopened, labeled]
+    workflow_dispatch:
+        inputs:
+            issue_number:
+                description: Issue number to enroll or recover
+                required: true
+                type: string
+
+permissions:
+    contents: read
+    issues: write
+
+concurrency:
+    group: agent-task-${{ github.event.issue.number || inputs.issue_number }}
+    cancel-in-progress: false
+
+jobs:
+    authorize:
+        name: Authorize intake
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        outputs:
+            authorized: ${{ steps.policy.outputs.authorized }}
+            reason: ${{ steps.policy.outputs.reason }}
+            issue_number: ${{ steps.policy.outputs.issue_number }}
+            content_id: ${{ steps.policy.outputs.content_id }}
+        steps:
+            - uses: actions/checkout@v7
+              with:
+                  persist-credentials: false
+                  ref: ${{ vars.AGENT_BASE_BRANCH || 'dev' }}
+
+            - uses: actions/setup-node@v6
+              with:
+                  node-version: '24'
+
+            - name: Check actor permission and enrollment event
+              id: policy
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}
+                  ISSUE_NUMBER: ${{ inputs.issue_number }}
+              run: node .github/codex/scripts/agent-loop.mjs authorize
+
+    handoff:
+        name: Prepare the Codex Cloud handoff
+        needs: authorize
+        if: needs.authorize.outputs.authorized == 'true'
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+        permissions:
+            contents: read
+            issues: write
+        steps:
+            - uses: actions/checkout@v7
+              with:
+                  persist-credentials: false
+                  ref: ${{ vars.AGENT_BASE_BRANCH || 'dev' }}
+
+            - uses: actions/setup-node@v6
+              with:
+                  node-version: '24'
+
+            - name: Enroll and synchronize the Project item
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}
+                  AGENT_PROJECT_TOKEN: ${{ secrets.AGENT_PROJECT_TOKEN }}
+                  AGENT_PROJECT_OWNER: ${{ vars.AGENT_PROJECT_OWNER }}
+                  AGENT_PROJECT_NUMBER: ${{ vars.AGENT_PROJECT_NUMBER }}
+                  AGENT_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                  ISSUE_NUMBER: ${{ needs.authorize.outputs.issue_number }}
+                  CONTENT_ID: ${{ needs.authorize.outputs.content_id }}
+              run: node .github/codex/scripts/agent-loop.mjs enroll
+
+            - name: Publish a subscription-backed Cloud handoff
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}
+                  AGENT_PROJECT_TOKEN: ${{ secrets.AGENT_PROJECT_TOKEN }}
+                  AGENT_PROJECT_OWNER: ${{ vars.AGENT_PROJECT_OWNER }}
+                  AGENT_PROJECT_NUMBER: ${{ vars.AGENT_PROJECT_NUMBER }}
+                  AGENT_BASE_BRANCH: ${{ vars.AGENT_BASE_BRANCH || 'dev' }}
+                  AGENT_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                  ISSUE_NUMBER: ${{ needs.authorize.outputs.issue_number }}
+                  CONTENT_ID: ${{ needs.authorize.outputs.content_id }}
+                  HANDOFF_MODE: initial
+                  FEEDBACK_COMMENT_ID: ''
+                  TRIAGE_PROMPT_TEMPLATE: .github/codex/prompts/triage.md
+              run: node .github/codex/scripts/agent-loop.mjs prepare-cloud-handoff


### PR DESCRIPTION
## Summary

- expose the bilingual, privacy-first Quick task Issue Form from the default branch
- activate trusted Issue intake and Issue-comment command workflows
- keep orchestration code on `dev`; every job checks out `AGENT_BASE_BRANCH` before running the versioned policy scripts

## Why

GitHub resolves Issue Forms and the `issues`, `issue_comment`, and `workflow_dispatch` event definitions from the repository default branch. The implementation is already published on `dev` in `95dbd8ae`, but these four entrypoint files must exist on `main` before the loop can receive live events.

## Safety and impact

- intake first authorizes a human collaborator with effective write permission before the Project token is exposed to a later job
- the workflow uses the maintainer's manually started, subscription-backed Codex Cloud environment; it contains no OpenAI API key and performs no automatic model call
- `/agent-run`, repository-writing workflows, automatic merge, and Issue closure remain disabled
- untrusted public Issues remain ordinary Issues and cannot enroll themselves into the managed loop

## Validation

- `task agent-loop:test` — 37 passed
- `task architecture:check`
- `task server:test`
- `task web:test` — 382 passed, 6 skipped
- `task verify:generated`
- `task compose:test`
- `task ci:site`
- `task web:test:video-semantic` — 2 passed in replay mode; stack and volumes removed afterward
- all four activation YAML files parsed successfully and the activation diff contains only those files
